### PR TITLE
feat: add dark mode and project showcase

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,9 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
+    <button id="theme-toggle" aria-label="Changer de thème">
+      <i class="fas fa-moon"></i>
+    </button>
     <header class="reveal">
       <div class="container">
         <h1>Mohamed Omar Baouch</h1>
@@ -76,6 +79,36 @@
           <div class="skill">Solutions PDM/PLM</div>
           <div class="skill">Conception &amp; Simulation</div>
           <div class="skill">Méthodologies de projet</div>
+        </div>
+      </div>
+    </section>
+
+    <section id="projects" class="reveal">
+      <div class="container">
+        <h2 class="section-title">Projets</h2>
+        <div class="projects">
+          <div class="project-card">
+            <h3>Implémentation PDM</h3>
+            <p>
+              Déploiement d'une solution SOLIDWORKS PDM pour un groupe
+              industriel avec formation des utilisateurs et automatisation des
+              flux de données.
+            </p>
+          </div>
+          <div class="project-card">
+            <h3>Optimisation de module radar</h3>
+            <p>
+              Conception mécanique et validation par calcul pour améliorer la
+              fiabilité d'un système radar embarqué.
+            </p>
+          </div>
+          <div class="project-card">
+            <h3>Outillage plastique</h3>
+            <p>
+              Étude et réalisation d'outillage pour pièces thermoplastiques dans
+              le secteur automobile.
+            </p>
+          </div>
         </div>
       </div>
     </section>

--- a/script.js
+++ b/script.js
@@ -16,3 +16,20 @@ const observer = new IntersectionObserver(
 );
 
 reveals.forEach((el) => observer.observe(el));
+
+// Dark mode toggle
+const toggle = document.getElementById('theme-toggle');
+const icon = toggle.querySelector('i');
+const setTheme = (dark) => {
+  document.body.classList.toggle('dark', dark);
+  icon.classList.toggle('fa-sun', dark);
+  icon.classList.toggle('fa-moon', !dark);
+};
+
+setTheme(localStorage.getItem('theme') === 'dark');
+
+toggle.addEventListener('click', () => {
+  const isDark = !document.body.classList.contains('dark');
+  setTheme(isDark);
+  localStorage.setItem('theme', isDark ? 'dark' : 'light');
+});

--- a/style.css
+++ b/style.css
@@ -17,6 +17,36 @@ body {
   line-height: 1.6;
   overflow-x: hidden;
 }
+
+body.dark {
+  --text: #e4e4e4;
+  --bg: #121212;
+  --light-bg: #1e1e1e;
+}
+
+#theme-toggle {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  background: var(--light-bg);
+  color: var(--text);
+  border: none;
+  border-radius: 50%;
+  width: 45px;
+  height: 45px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+  transition: background 0.3s ease, color 0.3s ease;
+  z-index: 1000;
+}
+
+#theme-toggle:hover {
+  background: var(--secondary);
+  color: #fff;
+}
 header {
   min-height: 100vh;
   display: flex;
@@ -116,6 +146,24 @@ h2.section-title::after {
   transition: transform 0.3s ease;
 }
 .skill:hover {
+  transform: translateY(-5px);
+}
+
+.projects {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 30px;
+}
+
+.project-card {
+  background: var(--light-bg);
+  padding: 30px;
+  border-radius: 12px;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.05);
+  transition: transform 0.3s ease;
+}
+
+.project-card:hover {
   transform: translateY(-5px);
 }
 form .form-group {


### PR DESCRIPTION
## Summary
- add theme toggle for light/dark mode
- showcase key engineering projects with new section and styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b9593b994832f8f78d79da0ac034b