### PR TITLE
Fix: unstick blog loader + blog-specific loading title

### DIFF
--- a/assets/js/loader.js
+++ b/assets/js/loader.js
@@ -1,0 +1,20 @@
+(function () {
+  function hideLoader() {
+    var loadingScreen = document.getElementById('loadingScreen');
+    var mainContainer = document.getElementById('mainContainer');
+    if (loadingScreen) {
+      loadingScreen.style.opacity = '0';
+      setTimeout(function () {
+        loadingScreen.style.display = 'none';
+        if (mainContainer) mainContainer.classList.add('show');
+      }, 300);
+    } else if (mainContainer) {
+      mainContainer.classList.add('show');
+    }
+  }
+
+  // Disparition normale quand tout est chargé
+  window.addEventListener('load', hideLoader);
+  // Filet de sécurité (si d’autres scripts plantent)
+  setTimeout(hideLoader, 3000);
+})();

--- a/blog/index.html
+++ b/blog/index.html
@@ -2286,7 +2286,7 @@
         <div class="loading-icon">
             <div class="loading-circle"></div>
         </div>
-        <div class="loader-title" data-translate-key="loading_portfolio">CHARGEMENT DU PORTFOLIO</div>
+        <div class="loader-title" data-translate-key="loading_blog">CHARGEMENT DU BLOG</div>
         <div class="loader-subtitle">Mohamed Omar Baouch</div>
         <div class="loading-bar-container">
             <div class="loading-bar" id="loadingBar"></div>
@@ -2870,8 +2870,7 @@
         .article-item .source { font-size: 0.9rem; color: var(--text-secondary); }
         .back-link { display: inline-block; margin-top: 2rem; color: var(--accent-secondary); font-weight: 600; }
     </style>
-</head>
-<body>
+
     <div class="container blog-container">
         <div class="blog-index">
             <h1>Blog - Radar PDM/PLM</h1>
@@ -2884,5 +2883,6 @@
              <a href="/" class="back-link">← Retour au portfolio</a>
         </div>
     </div>
+<script src="/assets/js/loader.js" defer></script>
 </body>
 </html>

--- a/blog/radar-2025-09-07/index.html
+++ b/blog/radar-2025-09-07/index.html
@@ -2286,7 +2286,7 @@
         <div class="loading-icon">
             <div class="loading-circle"></div>
         </div>
-        <div class="loader-title" data-translate-key="loading_portfolio">CHARGEMENT DU PORTFOLIO</div>
+        <div class="loader-title" data-translate-key="loading_blog">CHARGEMENT DU BLOG</div>
         <div class="loader-subtitle">Mohamed Omar Baouch</div>
         <div class="loading-bar-container">
             <div class="loading-bar" id="loadingBar"></div>
@@ -2870,8 +2870,7 @@
         .article-item .source { font-size: 0.9rem; color: var(--text-secondary); }
         .back-link { display: inline-block; margin-top: 2rem; color: var(--accent-secondary); font-weight: 600; }
     </style>
-</head>
-<body>
+
     <div class="container blog-container">
         <div class="blog-post">
             <h1>Radar PDM/PLM – 2025-09-07</h1>
@@ -2885,5 +2884,6 @@
             <a href="/blog/" class="back-link">← Voir tous les radars</a>
         </div>
     </div>
+<script src="/assets/js/loader.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add dedicated loader.js that hides the loading overlay with a 3s fallback
- swap loader title to “CHARGEMENT DU BLOG” on blog pages and include the script

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdf0c0242c832fb2bc1e8d8038b9df