### PR TITLE
Use feed dates and track processed links

### DIFF
--- a/history.json
+++ b/history.json
@@ -1,0 +1,3 @@
+{
+  "processedLinks": []
+}


### PR DESCRIPTION
## Summary
- prefer RSS item-provided dates (`isoDate`, `pubDate`, `date`) before defaulting to current time
- maintain a JSON history of processed links to avoid duplicate posts across runs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build-blog` *(fails: connect ENETUNREACH; No new items found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf35709340832f9ad0b0bd61a80496