### PR TITLE
Refactor blog landing layout with hero and filtering

### DIFF
--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -1,0 +1,461 @@
+.blog-container {
+    max-width: min(1100px, 92vw);
+    margin: 140px auto 80px;
+    padding: 0 1.5rem 4rem;
+    position: relative;
+    z-index: 1;
+}
+
+.blog-shell > * + * {
+    margin-top: 3.5rem;
+}
+
+.blog-hero {
+    background: linear-gradient(135deg, rgba(217, 122, 122, 0.14), rgba(229, 180, 142, 0.08));
+    border: 1px solid rgba(229, 180, 142, 0.25);
+    border-radius: 24px;
+    padding: clamp(2.5rem, 4vw, 3.5rem);
+    display: grid;
+    gap: clamp(2rem, 3vw, 3rem);
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    box-shadow: 0 25px 60px rgba(0, 0, 0, 0.35);
+    position: relative;
+    overflow: hidden;
+}
+
+.blog-hero::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(229, 180, 142, 0.35), transparent 60%),
+                radial-gradient(circle at 80% 0%, rgba(217, 122, 122, 0.25), transparent 55%);
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.blog-hero > * {
+    position: relative;
+    z-index: 1;
+}
+
+.hero-intro {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.hero-eyebrow {
+    font-size: 0.9rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--accent-secondary);
+}
+
+.hero-title {
+    font-size: clamp(2rem, 4vw, 3rem);
+    line-height: 1.15;
+}
+
+.hero-subtitle {
+    color: var(--text-secondary);
+    font-size: 1rem;
+    max-width: 40ch;
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.hero-btn,
+.hero-btn:visited {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.85rem 1.6rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 600;
+    background: var(--accent-gradient);
+    color: var(--bg-primary);
+    transition: transform var(--transition-speed), box-shadow var(--transition-speed);
+    box-shadow: 0 12px 30px rgba(217, 122, 122, 0.25);
+}
+
+.hero-btn:hover,
+.hero-btn:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 36px rgba(217, 122, 122, 0.35);
+}
+
+.hero-btn--ghost,
+.hero-btn--ghost:visited {
+    background: transparent;
+    border: 1px solid rgba(229, 180, 142, 0.45);
+    color: var(--text-primary);
+    box-shadow: none;
+}
+
+.hero-btn--ghost:hover,
+.hero-btn--ghost:focus-visible {
+    background: rgba(229, 180, 142, 0.12);
+    box-shadow: none;
+}
+
+.hero-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 1.25rem;
+    align-items: stretch;
+}
+
+.hero-stat {
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 18px;
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.hero-stat-value {
+    font-size: 2.15rem;
+    font-weight: 700;
+    color: var(--accent-secondary);
+}
+
+.hero-stat-label {
+    font-size: 0.85rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+
+.blog-controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.filter-group {
+    display: inline-flex;
+    gap: 0.65rem;
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 999px;
+    padding: 0.45rem;
+}
+
+.filter-btn {
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    font-weight: 600;
+    padding: 0.55rem 1.35rem;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background var(--transition-speed), color var(--transition-speed);
+}
+
+.filter-btn.is-active {
+    background: var(--accent-gradient);
+    color: var(--bg-primary);
+}
+
+.blog-section {
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 24px;
+    padding: clamp(2rem, 3vw, 3rem);
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 2rem;
+    align-items: center;
+}
+
+.section-header h2 {
+    font-size: clamp(1.4rem, 2.5vw, 2rem);
+}
+
+.section-subtitle {
+    color: var(--text-secondary);
+    max-width: 45ch;
+}
+
+.card-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.post-card {
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 18px;
+    padding: 1.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
+    position: relative;
+    overflow: hidden;
+    transition: transform var(--transition-speed), box-shadow var(--transition-speed), border-color var(--transition-speed);
+}
+
+.post-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(217, 122, 122, 0.15), transparent 60%);
+    opacity: 0;
+    transition: opacity var(--transition-speed);
+    pointer-events: none;
+}
+
+.post-card:hover,
+.post-card:focus-within {
+    transform: translateY(-4px);
+    border-color: rgba(229, 180, 142, 0.35);
+    box-shadow: 0 30px 55px rgba(217, 122, 122, 0.18);
+}
+
+.post-card:hover::after,
+.post-card:focus-within::after {
+    opacity: 1;
+}
+
+.post-card__meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.75rem;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    background: rgba(229, 180, 142, 0.12);
+    color: var(--accent-secondary);
+}
+
+.badge-radar {
+    background: rgba(217, 122, 122, 0.18);
+    color: var(--accent-primary);
+}
+
+.badge-editorial {
+    background: rgba(229, 180, 142, 0.18);
+    color: var(--accent-secondary);
+}
+
+.post-card__title {
+    font-size: 1.35rem;
+    line-height: 1.3;
+}
+
+.post-card__title a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.post-card__title a:hover,
+.post-card__title a:focus-visible {
+    color: var(--accent-secondary);
+}
+
+.post-card__excerpt {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+}
+
+.post-card__cta {
+    margin-top: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--accent-secondary);
+    font-weight: 600;
+    text-decoration: none;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+}
+
+.post-card__cta:hover,
+.post-card__cta:focus-visible {
+    color: var(--accent-primary);
+}
+
+.post-card__media {
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.post-card__media img {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+}
+
+.tag {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--text-secondary);
+    border-radius: 999px;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.75rem;
+}
+
+.blog-timeline-section {
+    padding-bottom: clamp(2.5rem, 4vw, 3.5rem);
+}
+
+.blog-timeline {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 1.5rem;
+    position: relative;
+}
+
+.timeline-item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 1rem;
+    align-items: flex-start;
+    opacity: 0.55;
+    transform: translateY(8px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.timeline-item.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.timeline-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--accent-gradient);
+    margin-top: 0.4rem;
+}
+
+.timeline-content {
+    border-left: 1px dashed rgba(255, 255, 255, 0.14);
+    padding-left: 1.25rem;
+}
+
+.timeline-content time {
+    display: block;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    margin-bottom: 0.35rem;
+}
+
+.timeline-content a {
+    color: var(--text-primary);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.timeline-content a:hover,
+.timeline-content a:focus-visible {
+    color: var(--accent-secondary);
+}
+
+.timeline-meta {
+    display: block;
+    margin-top: 0.35rem;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.empty-state {
+    padding: 1.5rem 1.75rem;
+    background: rgba(0, 0, 0, 0.25);
+    border-radius: 16px;
+    color: var(--text-secondary);
+}
+
+.is-hidden {
+    display: none !important;
+}
+
+.post-hero {
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+}
+
+.post-hero .hero-actions {
+    margin-top: 0.75rem;
+}
+
+.post-hero .hero-subtitle {
+    max-width: 55ch;
+}
+
+.radar-grid {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+@media (max-width: 900px) {
+    .blog-controls {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .blog-container {
+        margin: 110px auto 60px;
+    }
+}
+
+@media (max-width: 640px) {
+    .hero-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .filter-group {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .filter-btn {
+        flex: 1;
+        text-align: center;
+    }
+
+    .section-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}

--- a/assets/js/blog.js
+++ b/assets/js/blog.js
@@ -1,0 +1,128 @@
+const parseBlogData = () => {
+    const dataElement = document.getElementById('blog-data');
+    if (!dataElement) return null;
+    try {
+        return JSON.parse(dataElement.textContent.trim());
+    } catch (error) {
+        console.warn('[blog] Impossible de lire les données JSON :', error);
+        return null;
+    }
+};
+
+const updateHero = (heroData, filter) => {
+    if (!heroData) return;
+    const heroTitle = document.querySelector('[data-hero-title]');
+    const heroSubtitle = document.querySelector('[data-hero-subtitle]');
+    const heroLink = document.querySelector('[data-hero-link]');
+    const heroSecondary = document.querySelector('[data-hero-secondary]');
+
+    const preferredType = filter === 'editorial' ? 'editorial' : 'radar';
+    const highlight = preferredType === 'editorial'
+        ? heroData.editorialHighlight || heroData.radarHighlight
+        : heroData.radarHighlight || heroData.editorialHighlight;
+
+    if (!highlight) return;
+
+    if (heroTitle) {
+        heroTitle.textContent = highlight.title;
+    }
+    if (heroSubtitle) {
+        heroSubtitle.textContent = highlight.heroSubtitle || highlight.excerpt || '';
+    }
+    if (heroLink) {
+        heroLink.href = highlight.url;
+        heroLink.textContent = highlight.type === 'editorial'
+            ? "Lire l'article"
+            : (highlight.displayDate ? `Consulter le radar du ${highlight.displayDate}` : 'Consulter le radar');
+    }
+
+    if (heroSecondary) {
+        const alternate = highlight.type === 'editorial'
+            ? heroData.radarHighlight
+            : heroData.editorialHighlight;
+        if (alternate) {
+            heroSecondary.href = alternate.url;
+            heroSecondary.textContent = alternate.type === 'editorial'
+                ? "Lire l'article de fond"
+                : 'Voir le radar du jour';
+            heroSecondary.classList.remove('is-hidden');
+        } else {
+            heroSecondary.classList.add('is-hidden');
+        }
+    }
+};
+
+const applyFilter = (target, sections, buttons) => {
+    buttons.forEach((button) => {
+        const isActive = button.dataset.filter === target;
+        button.classList.toggle('is-active', isActive);
+        button.setAttribute('aria-pressed', String(isActive));
+    });
+
+    sections.forEach((section) => {
+        const sectionType = section.dataset.section;
+        const shouldShow = target === 'all' || sectionType === target;
+        section.classList.toggle('is-hidden', !shouldShow);
+    });
+};
+
+const initFilters = (blogData) => {
+    const filterGroup = document.querySelector('[data-filter-group]');
+    if (!filterGroup) return;
+
+    const buttons = Array.from(filterGroup.querySelectorAll('[data-filter]'));
+    const sections = Array.from(document.querySelectorAll('[data-section]'));
+    if (!buttons.length || !sections.length) return;
+
+    let currentFilter = 'all';
+
+    const setFilter = (target) => {
+        currentFilter = target;
+        applyFilter(target, sections, buttons);
+        const heroFilter = target === 'editorial' ? 'editorial' : 'radar';
+        updateHero(blogData?.hero, heroFilter);
+    };
+
+    filterGroup.addEventListener('click', (event) => {
+        const button = event.target.closest('[data-filter]');
+        if (!button) return;
+        const target = button.dataset.filter || 'all';
+        if (target === currentFilter) return;
+        setFilter(target);
+    });
+
+    // Initialise avec le filtre par défaut
+    setFilter('all');
+};
+
+const initTimeline = () => {
+    const items = document.querySelectorAll('.timeline-item');
+    if (!items.length || !('IntersectionObserver' in window)) return;
+
+    const observer = new IntersectionObserver((entries, obs) => {
+        entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('is-visible');
+                obs.unobserve(entry.target);
+            }
+        });
+    }, {
+        threshold: 0.2,
+        rootMargin: '0px 0px -10% 0px'
+    });
+
+    items.forEach((item) => observer.observe(item));
+};
+
+const initBlogPage = () => {
+    const blogData = parseBlogData();
+    initFilters(blogData);
+    updateHero(blogData?.hero, blogData?.hero?.radarHighlight ? 'radar' : 'editorial');
+    initTimeline();
+};
+
+if (document.readyState !== 'loading') {
+    initBlogPage();
+} else {
+    document.addEventListener('DOMContentLoaded', initBlogPage);
+}

--- a/blog-template.html
+++ b/blog-template.html
@@ -10,28 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Blog | Mohamed Omar Baouch</title> <meta name="description" content="Blog de Mohamed Omar Baouch sur le PDM/PLM et l'ingénierie.">
     <link rel="stylesheet" href="/assets/css/style.css">
-    <style>
-        /* Styles spécifiques au blog, que vous aviez dans les fichiers générés */
-        .blog-container { max-width: 900px; margin: 120px auto 40px !important; padding: 20px; }
-        .section { background-color: var(--bg-secondary); border-radius: 10px; padding: 2rem 3rem; box-shadow: 0 15px 35px rgba(0,0,0,0.3); border: 1px solid var(--bg-tertiary); }
-        .title { font-size: 2.5rem; color: var(--accent-primary); margin-bottom: 0.5rem; border-bottom: 2px solid var(--accent-secondary); padding-bottom: 0.5rem; display: inline-block; }
-        .meta { color: var(--text-secondary); margin-bottom: 2.5rem; font-style: italic; }
-        .post-item { border-bottom: 1px solid var(--bg-tertiary); padding: 1.5rem 0; transition: background-color 0.3s ease; margin: 0 -3rem; padding: 1.5rem 3rem; }
-        .post-item:last-child { border-bottom: none; }
-        .post-item:hover { background-color: var(--hover-color); }
-        .subtitle { margin: 0 0 0.5rem 0; font-size: 1.25rem; }
-        .subtitle a { color: var(--text-primary); text-decoration: none; transition: color 0.3s; }
-        .subtitle a:hover { color: var(--accent-primary); }
-        .post-item .meta { font-size: 0.85rem; margin-bottom: 0.5rem; color: var(--text-secondary); }
-        .post-item img { max-width: 100%; border-radius: 5px; margin-top: 1rem; margin-bottom: 0.5rem; }
-        .back { margin-top: 2rem; }
-        .back a { color: var(--accent-secondary); font-weight: 500; text-decoration: none; transition: color 0.3s; }
-        .back a:hover { color: var(--accent-primary); }
-        .post-list { list-style: none; padding: 0; }
-        .post-list-item { background-color: var(--hover-color); margin-bottom: 1rem; border-radius: 5px; transition: transform 0.3s ease, box-shadow 0.3s ease; }
-        .post-list-item:hover { transform: translateY(-3px); box-shadow: 0 8px 20px rgba(0,0,0,0.3); }
-        .post-list-item a { display: block; padding: 1rem 1.5rem; color: var(--text-primary); text-decoration: none; font-weight: 500; }
-    </style>
+    <link rel="stylesheet" href="/assets/css/blog.css">
 </head>
 <body class="blog-page">
     <canvas id="transition-canvas"></canvas>
@@ -75,7 +54,9 @@
     </div>
 
     <main id="mainContainer" class="container blog-container show">
-        {{BLOG_CONTENT}}
+        <div class="blog-shell" id="blogShell">
+            {{BLOG_CONTENT}}
+        </div>
     </main>
 
     <footer>
@@ -97,5 +78,6 @@
         </div>
 
     <script src="/assets/js/script.js"></script>
+    <script type="module" src="/assets/js/blog.js"></script>
 </body>
 </html>

--- a/scripts/generate-blog.mjs
+++ b/scripts/generate-blog.mjs
@@ -23,6 +23,64 @@ const MAX_ITEMS_PER_POST = 10;
 const args = process.argv.slice(2);
 const ITEMS_ONLY = args.includes('--items-only');
 
+const FRENCH_LONG_DATE = new Intl.DateTimeFormat('fr-FR', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric'
+});
+
+const FRENCH_SHORT_DATE = new Intl.DateTimeFormat('fr-FR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric'
+});
+
+const FRENCH_MONTH_YEAR = new Intl.DateTimeFormat('fr-FR', {
+    month: 'long',
+    year: 'numeric'
+});
+
+const pluralize = (value, singular, plural = `${singular}s`) => value > 1 ? plural : singular;
+
+const formatDisplayDate = (isoString) => {
+    if (!isoString) return '';
+    const parsed = new Date(isoString);
+    if (Number.isNaN(parsed.getTime())) return '';
+    return FRENCH_LONG_DATE.format(parsed);
+};
+
+const formatShortDisplayDate = (isoString) => {
+    if (!isoString) return '';
+    const parsed = new Date(isoString);
+    if (Number.isNaN(parsed.getTime())) return '';
+    return FRENCH_SHORT_DATE.format(parsed);
+};
+
+const formatMonthYear = (isoString) => {
+    if (!isoString) return '';
+    const parsed = new Date(isoString);
+    if (Number.isNaN(parsed.getTime())) return '';
+    return FRENCH_MONTH_YEAR.format(parsed);
+};
+
+const slugToISODate = (slug) => {
+    const match = slug.match(/radar-(\d{4}-\d{2}-\d{2})/);
+    if (!match) return null;
+    const [year, month, day] = match[1].split('-').map(Number);
+    if (!year || !month || !day) return null;
+    const date = new Date(Date.UTC(year, month - 1, day));
+    return date.toISOString();
+};
+
+const serializeJSON = (data) => {
+    return JSON.stringify(data, null, 2)
+        .replace(/</g, '\\u003C')
+        .replace(/>/g, '\\u003E')
+        .replace(/&/g, '\\u0026');
+};
+
+const cleanupText = (value = '') => value.replace(/&nbsp;/g, ' ').replace(/\s+/g, ' ').trim();
+
 // --- FONCTION TEMPLATE MISE À JOUR ---
 // Utilise blog-template.html
 async function getBlogTemplate(options = {}) {
@@ -106,6 +164,220 @@ async function fetchItems(processedLinks) {
     return { itemsForPost, noNews };
 }
 
+const highlightFromEntry = (entry) => {
+    if (!entry) return null;
+    return {
+        title: entry.title,
+        url: entry.url,
+        dateIso: entry.dateIso,
+        displayDate: entry.displayDate,
+        shortDate: entry.shortDate ?? null,
+        excerpt: entry.excerpt ?? '',
+        heroSubtitle: entry.heroSubtitle ?? entry.excerpt ?? '',
+        itemsCount: entry.itemsCount ?? null,
+        type: entry.type
+    };
+};
+
+async function readRadarMetadata(slug) {
+    const indexPath = path.join(BLOG_DIR, slug, 'index.html');
+    if (!await fs.pathExists(indexPath)) return null;
+    const html = await fs.readFile(indexPath, 'utf-8');
+    const titleMatch = html.match(/<title>(.*?)<\/title>/i);
+    const heroSubtitleMatch = html.match(/<p class="hero-subtitle">([^<]+)<\/p>/i) || html.match(/<p class="meta">([^<]+)<\/p>/i);
+    const newLayoutCount = (html.match(/data-entry-type="radar-item"/g) || []).length;
+    const legacyCount = (html.match(/class="post-item"/g) || []).length;
+    const itemsCount = newLayoutCount || legacyCount || null;
+    const dateIso = slugToISODate(slug);
+    const displayDate = formatDisplayDate(dateIso);
+    const shortDate = formatShortDisplayDate(dateIso);
+    const title = cleanupText(titleMatch ? titleMatch[1] : `Radar PDM/PLM – ${slug.replace('radar-', '')}`);
+    let excerpt = displayDate ? `Veille du ${displayDate}.` : 'Veille quotidienne PDM/PLM.';
+    if (itemsCount) {
+        excerpt += ` ${itemsCount} ${pluralize(itemsCount, 'signal')} sélectionné${itemsCount > 1 ? 's' : ''}.`;
+    }
+    const heroSubtitle = cleanupText(heroSubtitleMatch ? heroSubtitleMatch[1] : excerpt) || excerpt;
+    return {
+        slug,
+        url: `/blog/${slug}/`,
+        title,
+        dateIso,
+        displayDate,
+        shortDate,
+        excerpt: cleanupText(excerpt),
+        heroSubtitle,
+        itemsCount,
+        type: 'radar'
+    };
+}
+
+async function readEditorialMetadata(slug) {
+    const indexPath = path.join(BLOG_DIR, slug, 'index.html');
+    if (!await fs.pathExists(indexPath)) return null;
+    const html = await fs.readFile(indexPath, 'utf-8');
+    const titleMatch = html.match(/<title>(.*?)<\/title>/i);
+    const descriptionMatch = html.match(/<meta[^>]+name=["']description["'][^>]+content=["']([^"']+)["']/i);
+    const dateMatch = html.match(/(\d{2}\/\d{2}\/\d{4})/);
+    let dateIso = null;
+    if (dateMatch) {
+        const [day, month, year] = dateMatch[1].split('/').map(Number);
+        if (year && month && day) {
+            dateIso = new Date(Date.UTC(year, month - 1, day)).toISOString();
+        }
+    }
+    const displayDate = formatDisplayDate(dateIso);
+    const shortDate = formatShortDisplayDate(dateIso);
+    const title = cleanupText(titleMatch ? titleMatch[1] : slug.replace(/-/g, ' '));
+    const excerpt = cleanupText(descriptionMatch ? descriptionMatch[1] : 'Analyse éditoriale PDM/PLM.');
+    const heroSubtitle = displayDate ? cleanupText(`Publié le ${displayDate}. ${excerpt}`) : excerpt;
+    return {
+        slug,
+        url: `/blog/${slug}/`,
+        title,
+        dateIso,
+        displayDate,
+        shortDate,
+        excerpt,
+        heroSubtitle,
+        type: 'editorial'
+    };
+}
+
+function renderHeroSection(hero) {
+    if (!hero) return '';
+    const primaryTarget = hero.radarHighlight?.url || '/blog/';
+    const primaryLabel = hero.radarHighlight?.displayDate ? `Consulter le radar du ${hero.radarHighlight.displayDate}` : 'Explorer les radars';
+    const secondaryHiddenClass = hero.editorialHighlight ? '' : ' is-hidden';
+    const secondaryTarget = hero.editorialHighlight?.url || '#';
+    const secondaryLabel = hero.editorialHighlight ? "Lire l'article de fond" : 'Articles de fond';
+    const lastUpdate = hero.stats?.lastRadar ? hero.stats.lastRadar : null;
+    return `
+<section class="blog-hero" data-hero>
+  <div class="hero-intro">
+    <span class="hero-eyebrow">${escapeHTML(hero.tagline || 'Veille & analyses PDM/PLM')}</span>
+    <h1 class="hero-title" data-hero-title>${escapeHTML(hero.title)}</h1>
+    <p class="hero-subtitle" data-hero-subtitle>${escapeHTML(hero.subtitle)}</p>
+    <div class="hero-actions">
+      <a class="hero-btn" data-hero-link href="${escapeHTML(primaryTarget)}">${escapeHTML(primaryLabel)}</a>
+      <a class="hero-btn hero-btn--ghost${secondaryHiddenClass}" data-hero-secondary href="${escapeHTML(secondaryTarget)}">${escapeHTML(secondaryLabel)}</a>
+    </div>
+  </div>
+  <div class="hero-stats">
+    <div class="hero-stat">
+      <span class="hero-stat-value">${hero.stats?.radarCount ?? 0}</span>
+      <span class="hero-stat-label">Radars en ligne</span>
+    </div>
+    <div class="hero-stat">
+      <span class="hero-stat-value">${hero.stats?.editorialCount ?? 0}</span>
+      <span class="hero-stat-label">Articles de fond</span>
+    </div>
+    ${lastUpdate ? `
+    <div class="hero-stat">
+      <span class="hero-stat-value">${escapeHTML(lastUpdate)}</span>
+      <span class="hero-stat-label">Dernière mise à jour</span>
+    </div>` : ''}
+  </div>
+</section>
+`.trim();
+}
+
+function renderFilterControls() {
+    return `
+<section class="blog-controls">
+  <div class="filter-group" data-filter-group role="group" aria-label="Filtrer les contenus du blog">
+    <button class="filter-btn is-active" type="button" data-filter="all" aria-pressed="true">Tout</button>
+    <button class="filter-btn" type="button" data-filter="radar" aria-pressed="false">Radars</button>
+    <button class="filter-btn" type="button" data-filter="editorial" aria-pressed="false">Articles de fond</button>
+  </div>
+</section>
+`.trim();
+}
+
+function renderCardsSection({ title, description, entries = [], type, emptyMessage }) {
+    const hasEntries = entries.length > 0;
+    const subtitle = description ? `<p class="section-subtitle">${escapeHTML(description)}</p>` : '';
+    const body = hasEntries
+        ? `<div class="card-grid">${entries.map(renderCard).join('')}</div>`
+        : `<div class="empty-state"><p>${escapeHTML(emptyMessage || 'Contenu à venir.')}</p></div>`;
+    return `
+<section class="blog-section" data-section="${escapeHTML(type)}">
+  <div class="section-header">
+    <h2>${escapeHTML(title)}</h2>
+    ${subtitle}
+  </div>
+  ${body}
+</section>
+`.trim();
+}
+
+function renderCard(entry) {
+    const badgeClass = entry.type === 'editorial' ? 'badge-editorial' : 'badge-radar';
+    const badgeLabel = entry.type === 'editorial' ? 'Article de fond' : 'Radar';
+    const ctaLabel = entry.type === 'editorial' ? "Lire l'article" : 'Consulter le radar';
+    const dateMarkup = entry.displayDate
+        ? `<time${entry.dateIso ? ` datetime="${escapeHTML(entry.dateIso)}"` : ''}>${escapeHTML(entry.displayDate)}</time>`
+        : '';
+    const secondaryMeta = entry.itemsCount
+        ? `<span>${entry.itemsCount} ${pluralize(entry.itemsCount, 'lien')}</span>`
+        : '';
+    const excerpt = entry.excerpt ? `<p class="post-card__excerpt">${escapeHTML(entry.excerpt)}</p>` : '';
+    return `
+<article class="post-card" data-type="${escapeHTML(entry.type)}">
+  <div class="post-card__meta">
+    <span class="badge ${badgeClass}">${badgeLabel}</span>
+    ${dateMarkup}
+    ${secondaryMeta}
+  </div>
+  <h3 class="post-card__title"><a href="${escapeHTML(entry.url)}">${escapeHTML(entry.title)}</a></h3>
+  ${excerpt}
+  <a class="post-card__cta" href="${escapeHTML(entry.url)}">${ctaLabel}</a>
+</article>
+`.trim();
+}
+
+function renderTimelineSection(radars) {
+    if (!radars || radars.length === 0) return '';
+    const items = radars.slice(0, Math.min(12, radars.length));
+    const first = items[items.length - 1];
+    const last = items[0];
+    const periodLabel = first?.dateIso && last?.dateIso
+        ? `${formatDisplayDate(first.dateIso)} → ${formatDisplayDate(last.dateIso)}`
+        : null;
+    const subtitle = periodLabel
+        ? `Évolution des ${items.length} dernières publications (${periodLabel}).`
+        : `Évolution des ${items.length} dernières publications.`;
+    return `
+<section class="blog-section blog-timeline-section">
+  <div class="section-header">
+    <h2>Timeline du radar</h2>
+    <p class="section-subtitle">${escapeHTML(subtitle)}</p>
+  </div>
+  <ol class="blog-timeline">
+    ${items.map(renderTimelineItem).join('')}
+  </ol>
+</section>
+`.trim();
+}
+
+function renderTimelineItem(entry) {
+    const metaLine = entry.itemsCount
+        ? `<span class="timeline-meta">${entry.itemsCount} ${pluralize(entry.itemsCount, 'lien')}</span>`
+        : '';
+    const dateMarkup = entry.displayDate
+        ? `<time${entry.dateIso ? ` datetime="${escapeHTML(entry.dateIso)}"` : ''}>${escapeHTML(entry.displayDate)}</time>`
+        : '';
+    return `
+<li class="timeline-item">
+  <span class="timeline-dot"></span>
+  <div class="timeline-content">
+    ${dateMarkup}
+    <a href="${escapeHTML(entry.url)}">${escapeHTML(entry.title)}</a>
+    ${metaLine}
+  </div>
+</li>
+`.trim();
+}
+
 async function main() {
     console.log('Starting blog generation...');
     await fs.ensureDir(BLOG_DIR);
@@ -150,40 +422,108 @@ async function main() {
         if (!meta?.items) return '';
         const enriched = meta.items.find(m => m.link === item.link);
         if (!enriched) return '';
-        return `
-        ${enriched.image ? `<img src="${escapeHTML(enriched.image)}" alt="${escapeHTML(item.title)}">` : ''}
-        ${enriched.summary ? `<p>${escapeHTML(enriched.summary)}</p>` : ''}
-        ${enriched.keywords?.length ? `<p class="meta"><strong>Mots-clés:</strong> ${enriched.keywords.map(escapeHTML).join(', ')}</p>` : ''}
-        ${enriched.categories?.length ? `<p class="meta"><strong>Catégories:</strong> ${enriched.categories.map(escapeHTML).join(' / ')}</p>` : ''}
-        `;
+        const blocks = [];
+        if (enriched.image) {
+            blocks.push(`<figure class="post-card__media"><img src="${escapeHTML(enriched.image)}" alt="${escapeHTML(item.title)}"></figure>`);
+        }
+        if (enriched.summary) {
+            blocks.push(`<p class="post-card__excerpt">${escapeHTML(enriched.summary)}</p>`);
+        }
+        if (enriched.keywords?.length) {
+            const keywords = enriched.keywords.map(keyword => `<span class="tag">#${escapeHTML(keyword)}</span>`).join('');
+            blocks.push(`<div class="tag-list">${keywords}</div>`);
+        }
+        if (enriched.categories?.length) {
+            const categories = enriched.categories.map(category => `<span class="tag">${escapeHTML(category)}</span>`).join('');
+            blocks.push(`<div class="tag-list">${categories}</div>`);
+        }
+        return blocks.join('\n');
     }
-    const postContent = noNews ? `
-  <section class="section">
-    <p class="back"><a href="/blog/">← Voir tous les radars</a></p>
-    <h1 class="title">${escapeHTML(postTitle)}</h1>
-    <p class="meta">Aucune actualité aujourd'hui.</p>
-    <p class="back"><a href="/">← Retour au portfolio</a></p>
-  </section>
-` : `
-  <section class="section">
-    <p class="back"><a href="/blog/">← Voir tous les radars</a></p>
-    <h1 class="title">${escapeHTML(postTitle)}</h1>
-    <p class="meta">Veille du ${now.format('DD/MM/YYYY')} — PDM/PLM & écosystème.</p>
-    ${itemsForPost.map(item => `
-      <article class="post-item">
-        <h2 class="subtitle">
+    function renderRadarItem(item, index) {
+        return `
+      <article class="post-card" data-entry-type="radar-item">
+        <div class="post-card__meta">
+          <span class="badge badge-radar">Signal #${index + 1}</span>
+          <span>${escapeHTML(item.source)}</span>
+        </div>
+        <h3 class="post-card__title">
           <a href="${escapeHTML(item.link)}" target="_blank" rel="noopener noreferrer">
             ${escapeHTML(item.title)}
           </a>
-        </h2>
+        </h3>
         ${renderEnrichedMetaFor(item)}
-        <p class="meta">Source : ${escapeHTML(item.source)}</p>
+        <a class="post-card__cta" href="${escapeHTML(item.link)}" target="_blank" rel="noopener noreferrer">Ouvrir la source</a>
       </article>
-    `).join('')}
-    <p class="back"><a href="/">← Retour au portfolio</a></p>
-  </section>
+    `;
+    }
+
+    const publishedISO = now.toISOString();
+    const displayDate = formatDisplayDate(publishedISO);
+    const shortDisplayDate = formatShortDisplayDate(publishedISO);
+    const itemsCount = itemsForPost.length;
+    const uniqueSourcesCount = new Set(itemsForPost.map(item => item.source)).size;
+    const selectionSubtitle = `Sélection automatisée de ${itemsCount} ${pluralize(itemsCount, 'lien')} issue${itemsCount > 1 ? 's' : ''} de ${uniqueSourcesCount} ${pluralize(uniqueSourcesCount, 'source')}.`;
+
+    const postContent = noNews ? `
+<section class="blog-hero post-hero">
+  <div class="hero-intro">
+    <span class="hero-eyebrow">Radar quotidien</span>
+    <h1 class="hero-title">${escapeHTML(postTitle)}</h1>
+    <p class="hero-subtitle">Aucune actualité détectée pour le ${escapeHTML(displayDate)}.</p>
+    <div class="hero-actions">
+      <a class="hero-btn" href="/blog/">← Retour aux radars</a>
+      <a class="hero-btn hero-btn--ghost" href="/">Retour au portfolio</a>
+    </div>
+  </div>
+  <div class="hero-stats">
+    <div class="hero-stat">
+      <span class="hero-stat-value">${escapeHTML(shortDisplayDate)}</span>
+      <span class="hero-stat-label">Date de publication</span>
+    </div>
+  </div>
+</section>
+<section class="blog-section">
+  <div class="empty-state">
+    <p>Aucun signal détecté aujourd'hui. Revenez demain pour une nouvelle veille.</p>
+  </div>
+</section>
+` : `
+<section class="blog-hero post-hero">
+  <div class="hero-intro">
+    <span class="hero-eyebrow">Radar quotidien</span>
+    <h1 class="hero-title">${escapeHTML(postTitle)}</h1>
+    <p class="hero-subtitle">Veille du ${escapeHTML(displayDate)} — ${itemsCount} ${pluralize(itemsCount, 'signal')} sélectionné${itemsCount > 1 ? 's' : ''} auprès de ${uniqueSourcesCount} ${pluralize(uniqueSourcesCount, 'source')}.</p>
+    <div class="hero-actions">
+      <a class="hero-btn" href="/blog/">← Tous les radars</a>
+      <a class="hero-btn hero-btn--ghost" href="/">Retour au portfolio</a>
+    </div>
+  </div>
+  <div class="hero-stats">
+    <div class="hero-stat">
+      <span class="hero-stat-value">${itemsCount}</span>
+      <span class="hero-stat-label">${pluralize(itemsCount, 'Lien', 'Liens')} sélectionné${itemsCount > 1 ? 's' : ''}</span>
+    </div>
+    <div class="hero-stat">
+      <span class="hero-stat-value">${uniqueSourcesCount}</span>
+      <span class="hero-stat-label">${pluralize(uniqueSourcesCount, 'Source', 'Sources')} distincte${uniqueSourcesCount > 1 ? 's' : ''}</span>
+    </div>
+    <div class="hero-stat">
+      <span class="hero-stat-value">${escapeHTML(shortDisplayDate)}</span>
+      <span class="hero-stat-label">Date de publication</span>
+    </div>
+  </div>
+</section>
+<section class="blog-section">
+  <div class="section-header">
+    <h2>Les signaux du ${escapeHTML(displayDate)}</h2>
+    <p class="section-subtitle">${escapeHTML(selectionSubtitle)}</p>
+  </div>
+  <div class="card-grid radar-grid">
+    ${itemsForPost.map((item, index) => renderRadarItem(item, index)).join('')}
+  </div>
+</section>
 `;
-    const metaDescription = noNews ? "Aucune actualité aujourd'hui." : `Veille PDM/PLM du ${now.format('DD/MM/YYYY')}`;
+    const metaDescription = noNews ? "Aucune actualité aujourd'hui." : `Veille PDM/PLM du ${displayDate} – ${itemsCount} ${pluralize(itemsCount, 'lien')} sélectionné${itemsCount > 1 ? 's' : ''}.`;
     const postHTML = await generateHTMLPage(
         `Radar PDM/PLM – ${dateStr}`,
         postContent,
@@ -191,22 +531,106 @@ async function main() {
     );
     await fs.writeFile(path.join(postDir, 'index.html'), postHTML);
     console.log(`✅ Generated post: ${postSlug}`);
-    const allPostDirs = (await fs.readdir(BLOG_DIR)).filter(file => fs.statSync(path.join(BLOG_DIR, file)).isDirectory());
-    allPostDirs.sort().reverse();
-    const indexContent = `
-  <section class="section">
-    <h1 class="title">Blog — Radar PDM/PLM</h1>
-    <p class="meta">Veille technologique quotidienne et automatisée.</p>
-    <ul class="post-list">
-      ${allPostDirs.map(slug => `
-        <li class="post-list-item">
-          <a href="/blog/${slug}/">Radar — ${slug.replace('radar-', '')}</a>
-        </li>
-      `).join('')}
-    </ul>
-    <p class="back"><a href="/">← Retour au portfolio</a></p>
-  </section>
-`;
+    const entries = await fs.readdir(BLOG_DIR);
+    const radarDirs = [];
+    const editorialDirs = [];
+    for (const entry of entries) {
+        const fullPath = path.join(BLOG_DIR, entry);
+        if (!(await fs.stat(fullPath)).isDirectory()) continue;
+        if (entry.startsWith('radar-')) {
+            radarDirs.push(entry);
+        } else {
+            editorialDirs.push(entry);
+        }
+    }
+
+    const radarEntries = [];
+    for (const slug of radarDirs) {
+        const data = await readRadarMetadata(slug);
+        if (data) {
+            radarEntries.push(data);
+        }
+    }
+    radarEntries.sort((a, b) => {
+        if (a.dateIso && b.dateIso) {
+            return new Date(b.dateIso) - new Date(a.dateIso);
+        }
+        if (a.dateIso) return -1;
+        if (b.dateIso) return 1;
+        return b.slug.localeCompare(a.slug);
+    });
+
+    const editorialEntries = [];
+    for (const slug of editorialDirs) {
+        const data = await readEditorialMetadata(slug);
+        if (data) {
+            editorialEntries.push(data);
+        }
+    }
+    editorialEntries.sort((a, b) => {
+        if (a.dateIso && b.dateIso) {
+            return new Date(b.dateIso) - new Date(a.dateIso);
+        }
+        if (a.dateIso) return -1;
+        if (b.dateIso) return 1;
+        return a.title.localeCompare(b.title, 'fr');
+    });
+
+    const latestRadar = radarEntries[0] ?? null;
+    const latestEditorial = editorialEntries[0] ?? null;
+    const heroTitle = latestRadar?.title || latestEditorial?.title || 'Veille & analyses PDM/PLM';
+    const heroSubtitle = latestRadar?.heroSubtitle || latestEditorial?.heroSubtitle || 'Veille technologique quotidienne et retours d’expérience sur le PDM/PLM.';
+    const heroData = {
+        tagline: 'Radar & analyses PDM/PLM',
+        title: heroTitle,
+        subtitle: heroSubtitle,
+        radarHighlight: latestRadar,
+        editorialHighlight: latestEditorial,
+        stats: {
+            radarCount: radarEntries.length,
+            editorialCount: editorialEntries.length,
+            lastRadar: latestRadar?.shortDate || latestRadar?.displayDate || null
+        }
+    };
+
+    const timelineItems = radarEntries.slice(0, 12);
+    const blogData = {
+        generatedAt: publishedISO,
+        hero: {
+            tagline: heroData.tagline,
+            title: heroData.title,
+            subtitle: heroData.subtitle,
+            radarHighlight: highlightFromEntry(latestRadar),
+            editorialHighlight: highlightFromEntry(latestEditorial),
+            stats: heroData.stats
+        },
+        radars: radarEntries,
+        editorials: editorialEntries,
+        timeline: timelineItems
+    };
+
+    const indexSections = [
+        renderHeroSection(heroData),
+        renderFilterControls(),
+        renderCardsSection({
+            title: 'Radars quotidiens',
+            description: 'Veille automatisée sur le PDM/PLM, actualisée chaque jour ouvré.',
+            entries: radarEntries,
+            type: 'radar',
+            emptyMessage: 'Les premiers radars seront publiés très prochainement.'
+        }),
+        renderCardsSection({
+            title: 'Articles de fond',
+            description: 'Analyses éditoriales, retours d’expérience et bonnes pratiques terrain.',
+            entries: editorialEntries,
+            type: 'editorial',
+            emptyMessage: 'Les articles de fond arrivent bientôt.'
+        }),
+        renderTimelineSection(timelineItems),
+        `<script type="application/json" id="blog-data">${serializeJSON(blogData)}</script>`
+    ].filter(Boolean);
+
+    const indexContent = indexSections.join('\n\n');
     const indexHTML = await generateHTMLPage(
         'Blog — Radar PDM/PLM',
         indexContent,


### PR DESCRIPTION
## Summary
- restructure the blog template to load a dedicated layout shell and blog-specific assets
- add a blog stylesheet defining the hero, card grid, filter controls and timeline visuals
- enhance the blog generation script to build metadata, hero/timeline sections and emit JSON for the new layout
- introduce a client module to drive hero updates, filters and timeline animations on the blog homepage

## Testing
- node --check scripts/generate-blog.mjs
- node --check assets/js/blog.js

------
https://chatgpt.com/codex/tasks/task_e_68cd60c65fc0832fb3cfead63554cecc