### PR TITLE
Refactor blog layout and radar generation

### DIFF
--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -10,6 +10,282 @@
     margin-top: 3.5rem;
 }
 
+.blog-shell {
+    display: block;
+}
+
+.blog-article {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.75rem, 3vw, 2.75rem);
+}
+
+.blog-article > *:empty {
+    display: none;
+}
+
+.article-breadcrumbs {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.85rem 1.25rem;
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    width: fit-content;
+}
+
+.article-breadcrumbs__list {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: var(--accent-secondary);
+    font-weight: 600;
+    text-decoration: none;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.8rem;
+}
+
+.back-link:hover,
+.back-link:focus-visible {
+    color: var(--accent-primary);
+}
+
+.back-link--ghost {
+    color: var(--text-secondary);
+}
+
+.hero-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.hero-media {
+    border-radius: 20px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.04);
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+.hero-media img {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.hero-media figcaption {
+    padding: 0.85rem 1rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    background: rgba(0, 0, 0, 0.35);
+}
+
+.badge-neutral {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--text-primary);
+}
+
+.article-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    padding: clamp(1.5rem, 2.5vw, 2rem);
+}
+
+.summary-title {
+    margin: 0;
+    font-size: clamp(1.1rem, 1.8vw, 1.35rem);
+}
+
+.summary-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.summary-list li {
+    margin: 0;
+}
+
+.summary-list a {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.65rem 0.85rem;
+    border-radius: 12px;
+    text-decoration: none;
+    color: var(--text-primary);
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    transition: transform var(--transition-speed), border-color var(--transition-speed), background var(--transition-speed);
+}
+
+.summary-list a:hover,
+.summary-list a:focus-visible {
+    transform: translateY(-2px);
+    border-color: rgba(229, 180, 142, 0.35);
+    background: rgba(229, 180, 142, 0.15);
+}
+
+.summary-index {
+    font-weight: 700;
+    color: var(--accent-secondary);
+    font-size: 0.95rem;
+}
+
+.summary-label {
+    font-weight: 600;
+    line-height: 1.35;
+}
+
+.summary-meta {
+    display: block;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    margin-top: 0.15rem;
+    grid-column: 2 / -1;
+}
+
+.post-card__enrichment {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.media-grid {
+    display: grid;
+    gap: 1rem;
+}
+
+.media-card {
+    border-radius: 14px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.media-card img {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.media-card--text {
+    padding: 1rem 1.25rem;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+
+.media-card--text h3 {
+    margin: 0 0 0.5rem 0;
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-primary);
+}
+
+.media-card--text ul {
+    margin: 0;
+    padding-left: 1.1rem;
+    display: grid;
+    gap: 0.35rem;
+}
+
+.callout {
+    border-radius: 18px;
+    padding: clamp(1.5rem, 2.5vw, 2rem);
+    border: 1px solid rgba(229, 180, 142, 0.35);
+    background: rgba(229, 180, 142, 0.12);
+    color: var(--text-primary);
+}
+
+.callout--soft {
+    border-color: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.quote-block {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+}
+
+.quote-block blockquote {
+    margin: 0;
+    font-size: 1.1rem;
+    line-height: 1.6;
+    font-style: italic;
+    color: var(--accent-secondary);
+}
+
+.quote-block cite {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.feature-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.5rem 0;
+    font-size: 0.95rem;
+}
+
+.feature-table th,
+.feature-table td {
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 0.9rem 1rem;
+    text-align: left;
+}
+
+.feature-table thead {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.feature-table tbody tr:nth-child(odd) {
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.article-cta {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    text-align: center;
+}
+
+.cta-card {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    align-items: center;
+}
+
+.cta-card p {
+    color: var(--text-secondary);
+    max-width: 55ch;
+}
+
 .blog-hero {
     background: linear-gradient(135deg, rgba(217, 122, 122, 0.14), rgba(229, 180, 142, 0.08));
     border: 1px solid rgba(229, 180, 142, 0.25);

--- a/blog-template.html
+++ b/blog-template.html
@@ -54,8 +54,8 @@
     </div>
 
     <main id="mainContainer" class="container blog-container show">
-        <div class="blog-shell" id="blogShell">
-            {{BLOG_CONTENT}}
+        <div class="blog-shell" id="blogShell" data-shell>
+            <article class="blog-article" data-article-root>{{BLOG_NAVIGATION}}{{BLOG_HERO}}{{BLOG_SUMMARY}}{{BLOG_CONTENT}}{{BLOG_SIDEBAR}}{{BLOG_FOOTER}}</article>
         </div>
     </main>
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -10,28 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Blog — Radar PDM/PLM</title> <meta name="description" content="Veille PDM/PLM, SolidWorks, Teamcenter…">
     <link rel="stylesheet" href="/assets/css/style.css">
-    <style>
-        /* Styles spécifiques au blog, que vous aviez dans les fichiers générés */
-        .blog-container { max-width: 900px; margin: 120px auto 40px !important; padding: 20px; }
-        .section { background-color: var(--bg-secondary); border-radius: 10px; padding: 2rem 3rem; box-shadow: 0 15px 35px rgba(0,0,0,0.3); border: 1px solid var(--bg-tertiary); }
-        .title { font-size: 2.5rem; color: var(--accent-primary); margin-bottom: 0.5rem; border-bottom: 2px solid var(--accent-secondary); padding-bottom: 0.5rem; display: inline-block; }
-        .meta { color: var(--text-secondary); margin-bottom: 2.5rem; font-style: italic; }
-        .post-item { border-bottom: 1px solid var(--bg-tertiary); padding: 1.5rem 0; transition: background-color 0.3s ease; margin: 0 -3rem; padding: 1.5rem 3rem; }
-        .post-item:last-child { border-bottom: none; }
-        .post-item:hover { background-color: var(--hover-color); }
-        .subtitle { margin: 0 0 0.5rem 0; font-size: 1.25rem; }
-        .subtitle a { color: var(--text-primary); text-decoration: none; transition: color 0.3s; }
-        .subtitle a:hover { color: var(--accent-primary); }
-        .post-item .meta { font-size: 0.85rem; margin-bottom: 0.5rem; color: var(--text-secondary); }
-        .post-item img { max-width: 100%; border-radius: 5px; margin-top: 1rem; margin-bottom: 0.5rem; }
-        .back { margin-top: 2rem; }
-        .back a { color: var(--accent-secondary); font-weight: 500; text-decoration: none; transition: color 0.3s; }
-        .back a:hover { color: var(--accent-primary); }
-        .post-list { list-style: none; padding: 0; }
-        .post-list-item { background-color: var(--hover-color); margin-bottom: 1rem; border-radius: 5px; transition: transform 0.3s ease, box-shadow 0.3s ease; }
-        .post-list-item:hover { transform: translateY(-3px); box-shadow: 0 8px 20px rgba(0,0,0,0.3); }
-        .post-list-item a { display: block; padding: 1rem 1.5rem; color: var(--text-primary); text-decoration: none; font-weight: 500; }
-    </style>
+    <link rel="stylesheet" href="/assets/css/blog.css">
 </head>
 <body class="blog-page">
     <canvas id="transition-canvas"></canvas>
@@ -75,80 +54,669 @@
     </div>
 
     <main id="mainContainer" class="container blog-container show">
-        
-  <section class="section">
-    <h1 class="title">Blog — Radar PDM/PLM</h1>
-    <p class="meta">Veille technologique quotidienne et automatisée.</p>
-    <ul class="post-list">
-      
-        <li class="post-list-item">
-          <a href="/blog/resolutions-problematiques-plm/">Radar — resolutions-problematiques-plm</a>
-        </li>
-      
-        <li class="post-list-item">
-          <a href="/blog/radar-2025-09-21/">Radar — 2025-09-21</a>
-        </li>
-      
-        <li class="post-list-item">
-          <a href="/blog/radar-2025-09-20/">Radar — 2025-09-20</a>
-        </li>
-      
-        <li class="post-list-item">
-          <a href="/blog/radar-2025-09-19/">Radar — 2025-09-19</a>
-        </li>
-      
-        <li class="post-list-item">
-          <a href="/blog/radar-2025-09-18/">Radar — 2025-09-18</a>
-        </li>
-      
-        <li class="post-list-item">
-          <a href="/blog/radar-2025-09-17/">Radar — 2025-09-17</a>
-        </li>
-      
-        <li class="post-list-item">
-          <a href="/blog/radar-2025-09-16/">Radar — 2025-09-16</a>
-        </li>
-      
-        <li class="post-list-item">
-          <a href="/blog/radar-2025-09-15/">Radar — 2025-09-15</a>
-        </li>
-      
-        <li class="post-list-item">
-          <a href="/blog/radar-2025-09-14/">Radar — 2025-09-14</a>
-        </li>
-      
-        <li class="post-list-item">
-          <a href="/blog/radar-2025-09-13/">Radar — 2025-09-13</a>
-        </li>
-      
-        <li class="post-list-item">
-          <a href="/blog/radar-2025-09-12/">Radar — 2025-09-12</a>
-        </li>
-      
-        <li class="post-list-item">
-          <a href="/blog/radar-2025-09-11/">Radar — 2025-09-11</a>
-        </li>
-      
-        <li class="post-list-item">
-          <a href="/blog/radar-2025-09-10/">Radar — 2025-09-10</a>
-        </li>
-      
-        <li class="post-list-item">
-          <a href="/blog/radar-2025-09-09/">Radar — 2025-09-09</a>
-        </li>
-      
-        <li class="post-list-item">
-          <a href="/blog/radar-2025-09-08/">Radar — 2025-09-08</a>
-        </li>
-      
-        <li class="post-list-item">
-          <a href="/blog/radar-2025-09-07/">Radar — 2025-09-07</a>
-        </li>
-      
-    </ul>
-    <p class="back"><a href="/">← Retour au portfolio</a></p>
-  </section>
+        <div class="blog-shell" id="blogShell" data-shell>
+            <article class="blog-article" data-article-root><section class="blog-hero" data-hero>
+  <div class="hero-intro">
+    <span class="hero-eyebrow">Radar &amp; analyses PDM/PLM</span>
+    <h1 class="hero-title" data-hero-title>Radar PDM/PLM – 2025-09-21</h1>
+    <p class="hero-subtitle" data-hero-subtitle>Aucune actualité détectée pour le 21 septembre 2025.</p>
+    <div class="hero-actions">
+      <a class="hero-btn" data-hero-link href="/blog/radar-2025-09-21/">Consulter le radar du 21 septembre 2025</a>
+      <a class="hero-btn hero-btn--ghost" data-hero-secondary href="/blog/resolutions-problematiques-plm/">Lire l&#39;article de fond</a>
+    </div>
+  </div>
+  <div class="hero-stats">
+    <div class="hero-stat">
+      <span class="hero-stat-value">15</span>
+      <span class="hero-stat-label">Radars en ligne</span>
+    </div>
+    <div class="hero-stat">
+      <span class="hero-stat-value">1</span>
+      <span class="hero-stat-label">Articles de fond</span>
+    </div>
+    
+    <div class="hero-stat">
+      <span class="hero-stat-value">21/09/2025</span>
+      <span class="hero-stat-label">Dernière mise à jour</span>
+    </div>
+  </div>
+</section><section class="blog-controls">
+  <div class="filter-group" data-filter-group role="group" aria-label="Filtrer les contenus du blog">
+    <button class="filter-btn is-active" type="button" data-filter="all" aria-pressed="true">Tout</button>
+    <button class="filter-btn" type="button" data-filter="radar" aria-pressed="false">Radars</button>
+    <button class="filter-btn" type="button" data-filter="editorial" aria-pressed="false">Articles de fond</button>
+  </div>
+</section><section class="blog-section" data-section="radar">
+  <div class="section-header">
+    <h2>Radars quotidiens</h2>
+    <p class="section-subtitle">Veille automatisée sur le PDM/PLM, actualisée chaque jour ouvré.</p>
+  </div>
+  <div class="card-grid"><article class="post-card" data-type="radar">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Radar</span>
+    <time datetime="2025-09-21T00:00:00.000Z">21 septembre 2025</time>
+    
+  </div>
+  <h3 class="post-card__title"><a href="/blog/radar-2025-09-21/">Radar PDM/PLM – 2025-09-21</a></h3>
+  <p class="post-card__excerpt">Veille du 21 septembre 2025.</p>
+  <a class="post-card__cta" href="/blog/radar-2025-09-21/">Consulter le radar</a>
+</article><article class="post-card" data-type="radar">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Radar</span>
+    <time datetime="2025-09-20T00:00:00.000Z">20 septembre 2025</time>
+    
+  </div>
+  <h3 class="post-card__title"><a href="/blog/radar-2025-09-20/">Radar PDM/PLM – 2025-09-20</a></h3>
+  <p class="post-card__excerpt">Veille du 20 septembre 2025.</p>
+  <a class="post-card__cta" href="/blog/radar-2025-09-20/">Consulter le radar</a>
+</article><article class="post-card" data-type="radar">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Radar</span>
+    <time datetime="2025-09-19T00:00:00.000Z">19 septembre 2025</time>
+    <span>3 liens</span>
+  </div>
+  <h3 class="post-card__title"><a href="/blog/radar-2025-09-19/">Radar PDM/PLM – 2025-09-19</a></h3>
+  <p class="post-card__excerpt">Veille du 19 septembre 2025. 3 signals sélectionnés.</p>
+  <a class="post-card__cta" href="/blog/radar-2025-09-19/">Consulter le radar</a>
+</article><article class="post-card" data-type="radar">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Radar</span>
+    <time datetime="2025-09-18T00:00:00.000Z">18 septembre 2025</time>
+    <span>4 liens</span>
+  </div>
+  <h3 class="post-card__title"><a href="/blog/radar-2025-09-18/">Radar PDM/PLM – 2025-09-18</a></h3>
+  <p class="post-card__excerpt">Veille du 18 septembre 2025. 4 signals sélectionnés.</p>
+  <a class="post-card__cta" href="/blog/radar-2025-09-18/">Consulter le radar</a>
+</article><article class="post-card" data-type="radar">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Radar</span>
+    <time datetime="2025-09-17T00:00:00.000Z">17 septembre 2025</time>
+    <span>3 liens</span>
+  </div>
+  <h3 class="post-card__title"><a href="/blog/radar-2025-09-17/">Radar PDM/PLM – 2025-09-17</a></h3>
+  <p class="post-card__excerpt">Veille du 17 septembre 2025. 3 signals sélectionnés.</p>
+  <a class="post-card__cta" href="/blog/radar-2025-09-17/">Consulter le radar</a>
+</article><article class="post-card" data-type="radar">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Radar</span>
+    <time datetime="2025-09-16T00:00:00.000Z">16 septembre 2025</time>
+    <span>1 lien</span>
+  </div>
+  <h3 class="post-card__title"><a href="/blog/radar-2025-09-16/">Radar PDM/PLM – 2025-09-16</a></h3>
+  <p class="post-card__excerpt">Veille du 16 septembre 2025. 1 signal sélectionné.</p>
+  <a class="post-card__cta" href="/blog/radar-2025-09-16/">Consulter le radar</a>
+</article><article class="post-card" data-type="radar">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Radar</span>
+    <time datetime="2025-09-15T00:00:00.000Z">15 septembre 2025</time>
+    
+  </div>
+  <h3 class="post-card__title"><a href="/blog/radar-2025-09-15/">Radar PDM/PLM – 2025-09-15</a></h3>
+  <p class="post-card__excerpt">Veille du 15 septembre 2025.</p>
+  <a class="post-card__cta" href="/blog/radar-2025-09-15/">Consulter le radar</a>
+</article><article class="post-card" data-type="radar">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Radar</span>
+    <time datetime="2025-09-14T00:00:00.000Z">14 septembre 2025</time>
+    
+  </div>
+  <h3 class="post-card__title"><a href="/blog/radar-2025-09-14/">Radar PDM/PLM – 2025-09-14</a></h3>
+  <p class="post-card__excerpt">Veille du 14 septembre 2025.</p>
+  <a class="post-card__cta" href="/blog/radar-2025-09-14/">Consulter le radar</a>
+</article><article class="post-card" data-type="radar">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Radar</span>
+    <time datetime="2025-09-13T00:00:00.000Z">13 septembre 2025</time>
+    
+  </div>
+  <h3 class="post-card__title"><a href="/blog/radar-2025-09-13/">Radar PDM/PLM – 2025-09-13</a></h3>
+  <p class="post-card__excerpt">Veille du 13 septembre 2025.</p>
+  <a class="post-card__cta" href="/blog/radar-2025-09-13/">Consulter le radar</a>
+</article><article class="post-card" data-type="radar">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Radar</span>
+    <time datetime="2025-09-12T00:00:00.000Z">12 septembre 2025</time>
+    <span>1 lien</span>
+  </div>
+  <h3 class="post-card__title"><a href="/blog/radar-2025-09-12/">Radar PDM/PLM – 2025-09-12</a></h3>
+  <p class="post-card__excerpt">Veille du 12 septembre 2025. 1 signal sélectionné.</p>
+  <a class="post-card__cta" href="/blog/radar-2025-09-12/">Consulter le radar</a>
+</article><article class="post-card" data-type="radar">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Radar</span>
+    <time datetime="2025-09-11T00:00:00.000Z">11 septembre 2025</time>
+    <span>10 liens</span>
+  </div>
+  <h3 class="post-card__title"><a href="/blog/radar-2025-09-11/">Radar PDM/PLM – 2025-09-11</a></h3>
+  <p class="post-card__excerpt">Veille du 11 septembre 2025. 10 signals sélectionnés.</p>
+  <a class="post-card__cta" href="/blog/radar-2025-09-11/">Consulter le radar</a>
+</article><article class="post-card" data-type="radar">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Radar</span>
+    <time datetime="2025-09-10T00:00:00.000Z">10 septembre 2025</time>
+    <span>10 liens</span>
+  </div>
+  <h3 class="post-card__title"><a href="/blog/radar-2025-09-10/">Radar PDM/PLM – 2025-09-10</a></h3>
+  <p class="post-card__excerpt">Veille du 10 septembre 2025. 10 signals sélectionnés.</p>
+  <a class="post-card__cta" href="/blog/radar-2025-09-10/">Consulter le radar</a>
+</article><article class="post-card" data-type="radar">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Radar</span>
+    <time datetime="2025-09-09T00:00:00.000Z">9 septembre 2025</time>
+    <span>10 liens</span>
+  </div>
+  <h3 class="post-card__title"><a href="/blog/radar-2025-09-09/">Radar PDM/PLM – 2025-09-09</a></h3>
+  <p class="post-card__excerpt">Veille du 9 septembre 2025. 10 signals sélectionnés.</p>
+  <a class="post-card__cta" href="/blog/radar-2025-09-09/">Consulter le radar</a>
+</article><article class="post-card" data-type="radar">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Radar</span>
+    <time datetime="2025-09-08T00:00:00.000Z">8 septembre 2025</time>
+    
+  </div>
+  <h3 class="post-card__title"><a href="/blog/radar-2025-09-08/">Radar PDM/PLM – 2025-09-08</a></h3>
+  <p class="post-card__excerpt">Veille du 8 septembre 2025.</p>
+  <a class="post-card__cta" href="/blog/radar-2025-09-08/">Consulter le radar</a>
+</article><article class="post-card" data-type="radar">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Radar</span>
+    <time datetime="2025-09-07T00:00:00.000Z">7 septembre 2025</time>
+    
+  </div>
+  <h3 class="post-card__title"><a href="/blog/radar-2025-09-07/">Radar PDM/PLM – 2025-09-07 | Mohamed Omar Baouch</a></h3>
+  <p class="post-card__excerpt">Veille du 7 septembre 2025.</p>
+  <a class="post-card__cta" href="/blog/radar-2025-09-07/">Consulter le radar</a>
+</article></div>
+</section>
 
+<section class="blog-section" data-section="editorial">
+  <div class="section-header">
+    <h2>Articles de fond</h2>
+    <p class="section-subtitle">Analyses éditoriales, retours d’expérience et bonnes pratiques terrain.</p>
+  </div>
+  <div class="card-grid"><article class="post-card" data-type="editorial">
+  <div class="post-card__meta">
+    <span class="badge badge-editorial">Article de fond</span>
+    <time datetime="2025-09-15T00:00:00.000Z">15 septembre 2025</time>
+    
+  </div>
+  <h3 class="post-card__title"><a href="/blog/resolutions-problematiques-plm/">Au-delà de la théorie : résoudre les 5 problématiques PLM que j&#39;ai vécues en tant qu&#39;Ingénieur Mécanique</a></h3>
+  <p class="post-card__excerpt">Retour d</p>
+  <a class="post-card__cta" href="/blog/resolutions-problematiques-plm/">Lire l'article</a>
+</article></div>
+</section>
+
+<section class="blog-section blog-timeline-section">
+  <div class="section-header">
+    <h2>Timeline du radar</h2>
+    <p class="section-subtitle">Évolution des 12 dernières publications (10 septembre 2025 → 21 septembre 2025).</p>
+  </div>
+  <ol class="blog-timeline">
+    <li class="timeline-item">
+  <span class="timeline-dot"></span>
+  <div class="timeline-content">
+    <time datetime="2025-09-21T00:00:00.000Z">21 septembre 2025</time>
+    <a href="/blog/radar-2025-09-21/">Radar PDM/PLM – 2025-09-21</a>
+    
+  </div>
+</li><li class="timeline-item">
+  <span class="timeline-dot"></span>
+  <div class="timeline-content">
+    <time datetime="2025-09-20T00:00:00.000Z">20 septembre 2025</time>
+    <a href="/blog/radar-2025-09-20/">Radar PDM/PLM – 2025-09-20</a>
+    
+  </div>
+</li><li class="timeline-item">
+  <span class="timeline-dot"></span>
+  <div class="timeline-content">
+    <time datetime="2025-09-19T00:00:00.000Z">19 septembre 2025</time>
+    <a href="/blog/radar-2025-09-19/">Radar PDM/PLM – 2025-09-19</a>
+    <span class="timeline-meta">3 liens</span>
+  </div>
+</li><li class="timeline-item">
+  <span class="timeline-dot"></span>
+  <div class="timeline-content">
+    <time datetime="2025-09-18T00:00:00.000Z">18 septembre 2025</time>
+    <a href="/blog/radar-2025-09-18/">Radar PDM/PLM – 2025-09-18</a>
+    <span class="timeline-meta">4 liens</span>
+  </div>
+</li><li class="timeline-item">
+  <span class="timeline-dot"></span>
+  <div class="timeline-content">
+    <time datetime="2025-09-17T00:00:00.000Z">17 septembre 2025</time>
+    <a href="/blog/radar-2025-09-17/">Radar PDM/PLM – 2025-09-17</a>
+    <span class="timeline-meta">3 liens</span>
+  </div>
+</li><li class="timeline-item">
+  <span class="timeline-dot"></span>
+  <div class="timeline-content">
+    <time datetime="2025-09-16T00:00:00.000Z">16 septembre 2025</time>
+    <a href="/blog/radar-2025-09-16/">Radar PDM/PLM – 2025-09-16</a>
+    <span class="timeline-meta">1 lien</span>
+  </div>
+</li><li class="timeline-item">
+  <span class="timeline-dot"></span>
+  <div class="timeline-content">
+    <time datetime="2025-09-15T00:00:00.000Z">15 septembre 2025</time>
+    <a href="/blog/radar-2025-09-15/">Radar PDM/PLM – 2025-09-15</a>
+    
+  </div>
+</li><li class="timeline-item">
+  <span class="timeline-dot"></span>
+  <div class="timeline-content">
+    <time datetime="2025-09-14T00:00:00.000Z">14 septembre 2025</time>
+    <a href="/blog/radar-2025-09-14/">Radar PDM/PLM – 2025-09-14</a>
+    
+  </div>
+</li><li class="timeline-item">
+  <span class="timeline-dot"></span>
+  <div class="timeline-content">
+    <time datetime="2025-09-13T00:00:00.000Z">13 septembre 2025</time>
+    <a href="/blog/radar-2025-09-13/">Radar PDM/PLM – 2025-09-13</a>
+    
+  </div>
+</li><li class="timeline-item">
+  <span class="timeline-dot"></span>
+  <div class="timeline-content">
+    <time datetime="2025-09-12T00:00:00.000Z">12 septembre 2025</time>
+    <a href="/blog/radar-2025-09-12/">Radar PDM/PLM – 2025-09-12</a>
+    <span class="timeline-meta">1 lien</span>
+  </div>
+</li><li class="timeline-item">
+  <span class="timeline-dot"></span>
+  <div class="timeline-content">
+    <time datetime="2025-09-11T00:00:00.000Z">11 septembre 2025</time>
+    <a href="/blog/radar-2025-09-11/">Radar PDM/PLM – 2025-09-11</a>
+    <span class="timeline-meta">10 liens</span>
+  </div>
+</li><li class="timeline-item">
+  <span class="timeline-dot"></span>
+  <div class="timeline-content">
+    <time datetime="2025-09-10T00:00:00.000Z">10 septembre 2025</time>
+    <a href="/blog/radar-2025-09-10/">Radar PDM/PLM – 2025-09-10</a>
+    <span class="timeline-meta">10 liens</span>
+  </div>
+</li>
+  </ol>
+</section>
+
+<script type="application/json" id="blog-data">{
+  "generatedAt": "2025-09-21T13:29:56.244Z",
+  "hero": {
+    "tagline": "Radar \u0026 analyses PDM/PLM",
+    "title": "Radar PDM/PLM – 2025-09-21",
+    "subtitle": "Aucune actualité détectée pour le 21 septembre 2025.",
+    "radarHighlight": {
+      "title": "Radar PDM/PLM – 2025-09-21",
+      "url": "/blog/radar-2025-09-21/",
+      "dateIso": "2025-09-21T00:00:00.000Z",
+      "displayDate": "21 septembre 2025",
+      "shortDate": "21/09/2025",
+      "excerpt": "Veille du 21 septembre 2025.",
+      "heroSubtitle": "Aucune actualité détectée pour le 21 septembre 2025.",
+      "itemsCount": null,
+      "type": "radar"
+    },
+    "editorialHighlight": {
+      "title": "Au-delà de la théorie : résoudre les 5 problématiques PLM que j'ai vécues en tant qu'Ingénieur Mécanique",
+      "url": "/blog/resolutions-problematiques-plm/",
+      "dateIso": "2025-09-15T00:00:00.000Z",
+      "displayDate": "15 septembre 2025",
+      "shortDate": "15/09/2025",
+      "excerpt": "Retour d",
+      "heroSubtitle": "Publié le 15 septembre 2025. Retour d",
+      "itemsCount": null,
+      "type": "editorial"
+    },
+    "stats": {
+      "radarCount": 15,
+      "editorialCount": 1,
+      "lastRadar": "21/09/2025"
+    }
+  },
+  "radars": [
+    {
+      "slug": "radar-2025-09-21",
+      "url": "/blog/radar-2025-09-21/",
+      "title": "Radar PDM/PLM – 2025-09-21",
+      "dateIso": "2025-09-21T00:00:00.000Z",
+      "displayDate": "21 septembre 2025",
+      "shortDate": "21/09/2025",
+      "excerpt": "Veille du 21 septembre 2025.",
+      "heroSubtitle": "Aucune actualité détectée pour le 21 septembre 2025.",
+      "itemsCount": null,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-20",
+      "url": "/blog/radar-2025-09-20/",
+      "title": "Radar PDM/PLM – 2025-09-20",
+      "dateIso": "2025-09-20T00:00:00.000Z",
+      "displayDate": "20 septembre 2025",
+      "shortDate": "20/09/2025",
+      "excerpt": "Veille du 20 septembre 2025.",
+      "heroSubtitle": "Aucune actualité aujourd'hui.",
+      "itemsCount": null,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-19",
+      "url": "/blog/radar-2025-09-19/",
+      "title": "Radar PDM/PLM – 2025-09-19",
+      "dateIso": "2025-09-19T00:00:00.000Z",
+      "displayDate": "19 septembre 2025",
+      "shortDate": "19/09/2025",
+      "excerpt": "Veille du 19 septembre 2025. 3 signals sélectionnés.",
+      "heroSubtitle": "Veille du 19/09/2025 — PDM/PLM \u0026 écosystème.",
+      "itemsCount": 3,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-18",
+      "url": "/blog/radar-2025-09-18/",
+      "title": "Radar PDM/PLM – 2025-09-18",
+      "dateIso": "2025-09-18T00:00:00.000Z",
+      "displayDate": "18 septembre 2025",
+      "shortDate": "18/09/2025",
+      "excerpt": "Veille du 18 septembre 2025. 4 signals sélectionnés.",
+      "heroSubtitle": "Veille du 18/09/2025 — PDM/PLM \u0026 écosystème.",
+      "itemsCount": 4,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-17",
+      "url": "/blog/radar-2025-09-17/",
+      "title": "Radar PDM/PLM – 2025-09-17",
+      "dateIso": "2025-09-17T00:00:00.000Z",
+      "displayDate": "17 septembre 2025",
+      "shortDate": "17/09/2025",
+      "excerpt": "Veille du 17 septembre 2025. 3 signals sélectionnés.",
+      "heroSubtitle": "Veille du 17/09/2025 — PDM/PLM \u0026 écosystème.",
+      "itemsCount": 3,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-16",
+      "url": "/blog/radar-2025-09-16/",
+      "title": "Radar PDM/PLM – 2025-09-16",
+      "dateIso": "2025-09-16T00:00:00.000Z",
+      "displayDate": "16 septembre 2025",
+      "shortDate": "16/09/2025",
+      "excerpt": "Veille du 16 septembre 2025. 1 signal sélectionné.",
+      "heroSubtitle": "Veille du 16/09/2025 — PDM/PLM \u0026 écosystème.",
+      "itemsCount": 1,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-15",
+      "url": "/blog/radar-2025-09-15/",
+      "title": "Radar PDM/PLM – 2025-09-15",
+      "dateIso": "2025-09-15T00:00:00.000Z",
+      "displayDate": "15 septembre 2025",
+      "shortDate": "15/09/2025",
+      "excerpt": "Veille du 15 septembre 2025.",
+      "heroSubtitle": "Aucune actualité aujourd'hui.",
+      "itemsCount": null,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-14",
+      "url": "/blog/radar-2025-09-14/",
+      "title": "Radar PDM/PLM – 2025-09-14",
+      "dateIso": "2025-09-14T00:00:00.000Z",
+      "displayDate": "14 septembre 2025",
+      "shortDate": "14/09/2025",
+      "excerpt": "Veille du 14 septembre 2025.",
+      "heroSubtitle": "Aucune actualité aujourd'hui.",
+      "itemsCount": null,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-13",
+      "url": "/blog/radar-2025-09-13/",
+      "title": "Radar PDM/PLM – 2025-09-13",
+      "dateIso": "2025-09-13T00:00:00.000Z",
+      "displayDate": "13 septembre 2025",
+      "shortDate": "13/09/2025",
+      "excerpt": "Veille du 13 septembre 2025.",
+      "heroSubtitle": "Aucune actualité aujourd'hui.",
+      "itemsCount": null,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-12",
+      "url": "/blog/radar-2025-09-12/",
+      "title": "Radar PDM/PLM – 2025-09-12",
+      "dateIso": "2025-09-12T00:00:00.000Z",
+      "displayDate": "12 septembre 2025",
+      "shortDate": "12/09/2025",
+      "excerpt": "Veille du 12 septembre 2025. 1 signal sélectionné.",
+      "heroSubtitle": "Veille du 12/09/2025 — PDM/PLM \u0026 écosystème.",
+      "itemsCount": 1,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-11",
+      "url": "/blog/radar-2025-09-11/",
+      "title": "Radar PDM/PLM – 2025-09-11",
+      "dateIso": "2025-09-11T00:00:00.000Z",
+      "displayDate": "11 septembre 2025",
+      "shortDate": "11/09/2025",
+      "excerpt": "Veille du 11 septembre 2025. 10 signals sélectionnés.",
+      "heroSubtitle": "Veille du 11/09/2025 — PDM/PLM \u0026 écosystème.",
+      "itemsCount": 10,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-10",
+      "url": "/blog/radar-2025-09-10/",
+      "title": "Radar PDM/PLM – 2025-09-10",
+      "dateIso": "2025-09-10T00:00:00.000Z",
+      "displayDate": "10 septembre 2025",
+      "shortDate": "10/09/2025",
+      "excerpt": "Veille du 10 septembre 2025. 10 signals sélectionnés.",
+      "heroSubtitle": "Source : Reddit r/SolidWorks",
+      "itemsCount": 10,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-09",
+      "url": "/blog/radar-2025-09-09/",
+      "title": "Radar PDM/PLM – 2025-09-09",
+      "dateIso": "2025-09-09T00:00:00.000Z",
+      "displayDate": "9 septembre 2025",
+      "shortDate": "09/09/2025",
+      "excerpt": "Veille du 9 septembre 2025. 10 signals sélectionnés.",
+      "heroSubtitle": "Source : Reddit r/SolidWorks",
+      "itemsCount": 10,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-08",
+      "url": "/blog/radar-2025-09-08/",
+      "title": "Radar PDM/PLM – 2025-09-08",
+      "dateIso": "2025-09-08T00:00:00.000Z",
+      "displayDate": "8 septembre 2025",
+      "shortDate": "08/09/2025",
+      "excerpt": "Veille du 8 septembre 2025.",
+      "heroSubtitle": "Aucune actualité aujourd'hui.",
+      "itemsCount": null,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-07",
+      "url": "/blog/radar-2025-09-07/",
+      "title": "Radar PDM/PLM – 2025-09-07 | Mohamed Omar Baouch",
+      "dateIso": "2025-09-07T00:00:00.000Z",
+      "displayDate": "7 septembre 2025",
+      "shortDate": "07/09/2025",
+      "excerpt": "Veille du 7 septembre 2025.",
+      "heroSubtitle": "Une sélection des dernières actualités du 07/09/2025.",
+      "itemsCount": null,
+      "type": "radar"
+    }
+  ],
+  "editorials": [
+    {
+      "slug": "resolutions-problematiques-plm",
+      "url": "/blog/resolutions-problematiques-plm/",
+      "title": "Au-delà de la théorie : résoudre les 5 problématiques PLM que j'ai vécues en tant qu'Ingénieur Mécanique",
+      "dateIso": "2025-09-15T00:00:00.000Z",
+      "displayDate": "15 septembre 2025",
+      "shortDate": "15/09/2025",
+      "excerpt": "Retour d",
+      "heroSubtitle": "Publié le 15 septembre 2025. Retour d",
+      "type": "editorial"
+    }
+  ],
+  "timeline": [
+    {
+      "slug": "radar-2025-09-21",
+      "url": "/blog/radar-2025-09-21/",
+      "title": "Radar PDM/PLM – 2025-09-21",
+      "dateIso": "2025-09-21T00:00:00.000Z",
+      "displayDate": "21 septembre 2025",
+      "shortDate": "21/09/2025",
+      "excerpt": "Veille du 21 septembre 2025.",
+      "heroSubtitle": "Aucune actualité détectée pour le 21 septembre 2025.",
+      "itemsCount": null,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-20",
+      "url": "/blog/radar-2025-09-20/",
+      "title": "Radar PDM/PLM – 2025-09-20",
+      "dateIso": "2025-09-20T00:00:00.000Z",
+      "displayDate": "20 septembre 2025",
+      "shortDate": "20/09/2025",
+      "excerpt": "Veille du 20 septembre 2025.",
+      "heroSubtitle": "Aucune actualité aujourd'hui.",
+      "itemsCount": null,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-19",
+      "url": "/blog/radar-2025-09-19/",
+      "title": "Radar PDM/PLM – 2025-09-19",
+      "dateIso": "2025-09-19T00:00:00.000Z",
+      "displayDate": "19 septembre 2025",
+      "shortDate": "19/09/2025",
+      "excerpt": "Veille du 19 septembre 2025. 3 signals sélectionnés.",
+      "heroSubtitle": "Veille du 19/09/2025 — PDM/PLM \u0026 écosystème.",
+      "itemsCount": 3,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-18",
+      "url": "/blog/radar-2025-09-18/",
+      "title": "Radar PDM/PLM – 2025-09-18",
+      "dateIso": "2025-09-18T00:00:00.000Z",
+      "displayDate": "18 septembre 2025",
+      "shortDate": "18/09/2025",
+      "excerpt": "Veille du 18 septembre 2025. 4 signals sélectionnés.",
+      "heroSubtitle": "Veille du 18/09/2025 — PDM/PLM \u0026 écosystème.",
+      "itemsCount": 4,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-17",
+      "url": "/blog/radar-2025-09-17/",
+      "title": "Radar PDM/PLM – 2025-09-17",
+      "dateIso": "2025-09-17T00:00:00.000Z",
+      "displayDate": "17 septembre 2025",
+      "shortDate": "17/09/2025",
+      "excerpt": "Veille du 17 septembre 2025. 3 signals sélectionnés.",
+      "heroSubtitle": "Veille du 17/09/2025 — PDM/PLM \u0026 écosystème.",
+      "itemsCount": 3,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-16",
+      "url": "/blog/radar-2025-09-16/",
+      "title": "Radar PDM/PLM – 2025-09-16",
+      "dateIso": "2025-09-16T00:00:00.000Z",
+      "displayDate": "16 septembre 2025",
+      "shortDate": "16/09/2025",
+      "excerpt": "Veille du 16 septembre 2025. 1 signal sélectionné.",
+      "heroSubtitle": "Veille du 16/09/2025 — PDM/PLM \u0026 écosystème.",
+      "itemsCount": 1,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-15",
+      "url": "/blog/radar-2025-09-15/",
+      "title": "Radar PDM/PLM – 2025-09-15",
+      "dateIso": "2025-09-15T00:00:00.000Z",
+      "displayDate": "15 septembre 2025",
+      "shortDate": "15/09/2025",
+      "excerpt": "Veille du 15 septembre 2025.",
+      "heroSubtitle": "Aucune actualité aujourd'hui.",
+      "itemsCount": null,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-14",
+      "url": "/blog/radar-2025-09-14/",
+      "title": "Radar PDM/PLM – 2025-09-14",
+      "dateIso": "2025-09-14T00:00:00.000Z",
+      "displayDate": "14 septembre 2025",
+      "shortDate": "14/09/2025",
+      "excerpt": "Veille du 14 septembre 2025.",
+      "heroSubtitle": "Aucune actualité aujourd'hui.",
+      "itemsCount": null,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-13",
+      "url": "/blog/radar-2025-09-13/",
+      "title": "Radar PDM/PLM – 2025-09-13",
+      "dateIso": "2025-09-13T00:00:00.000Z",
+      "displayDate": "13 septembre 2025",
+      "shortDate": "13/09/2025",
+      "excerpt": "Veille du 13 septembre 2025.",
+      "heroSubtitle": "Aucune actualité aujourd'hui.",
+      "itemsCount": null,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-12",
+      "url": "/blog/radar-2025-09-12/",
+      "title": "Radar PDM/PLM – 2025-09-12",
+      "dateIso": "2025-09-12T00:00:00.000Z",
+      "displayDate": "12 septembre 2025",
+      "shortDate": "12/09/2025",
+      "excerpt": "Veille du 12 septembre 2025. 1 signal sélectionné.",
+      "heroSubtitle": "Veille du 12/09/2025 — PDM/PLM \u0026 écosystème.",
+      "itemsCount": 1,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-11",
+      "url": "/blog/radar-2025-09-11/",
+      "title": "Radar PDM/PLM – 2025-09-11",
+      "dateIso": "2025-09-11T00:00:00.000Z",
+      "displayDate": "11 septembre 2025",
+      "shortDate": "11/09/2025",
+      "excerpt": "Veille du 11 septembre 2025. 10 signals sélectionnés.",
+      "heroSubtitle": "Veille du 11/09/2025 — PDM/PLM \u0026 écosystème.",
+      "itemsCount": 10,
+      "type": "radar"
+    },
+    {
+      "slug": "radar-2025-09-10",
+      "url": "/blog/radar-2025-09-10/",
+      "title": "Radar PDM/PLM – 2025-09-10",
+      "dateIso": "2025-09-10T00:00:00.000Z",
+      "displayDate": "10 septembre 2025",
+      "shortDate": "10/09/2025",
+      "excerpt": "Veille du 10 septembre 2025. 10 signals sélectionnés.",
+      "heroSubtitle": "Source : Reddit r/SolidWorks",
+      "itemsCount": 10,
+      "type": "radar"
+    }
+  ]
+}</script></article>
+        </div>
     </main>
 
     <footer>
@@ -170,5 +738,6 @@
         </div>
 
     <script src="/assets/js/script.js"></script>
+    <script type="module" src="/assets/js/blog.js"></script>
 </body>
 </html>

--- a/blog/radar-2025-09-19/index.html
+++ b/blog/radar-2025-09-19/index.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html lang="fr">
 <head>
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -10,28 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Radar PDM/PLM – 2025-09-19</title> <meta name="description" content="Veille PDM/PLM du 19/09/2025">
     <link rel="stylesheet" href="/assets/css/style.css">
-    <style>
-        /* Styles spécifiques au blog, que vous aviez dans les fichiers générés */
-        .blog-container { max-width: 900px; margin: 120px auto 40px !important; padding: 20px; }
-        .section { background-color: var(--bg-secondary); border-radius: 10px; padding: 2rem 3rem; box-shadow: 0 15px 35px rgba(0,0,0,0.3); border: 1px solid var(--bg-tertiary); }
-        .title { font-size: 2.5rem; color: var(--accent-primary); margin-bottom: 0.5rem; border-bottom: 2px solid var(--accent-secondary); padding-bottom: 0.5rem; display: inline-block; }
-        .meta { color: var(--text-secondary); margin-bottom: 2.5rem; font-style: italic; }
-        .post-item { border-bottom: 1px solid var(--bg-tertiary); padding: 1.5rem 0; transition: background-color 0.3s ease; margin: 0 -3rem; padding: 1.5rem 3rem; }
-        .post-item:last-child { border-bottom: none; }
-        .post-item:hover { background-color: var(--hover-color); }
-        .subtitle { margin: 0 0 0.5rem 0; font-size: 1.25rem; }
-        .subtitle a { color: var(--text-primary); text-decoration: none; transition: color 0.3s; }
-        .subtitle a:hover { color: var(--accent-primary); }
-        .post-item .meta { font-size: 0.85rem; margin-bottom: 0.5rem; color: var(--text-secondary); }
-        .post-item img { max-width: 100%; border-radius: 5px; margin-top: 1rem; margin-bottom: 0.5rem; }
-        .back { margin-top: 2rem; }
-        .back a { color: var(--accent-secondary); font-weight: 500; text-decoration: none; transition: color 0.3s; }
-        .back a:hover { color: var(--accent-primary); }
-        .post-list { list-style: none; padding: 0; }
-        .post-list-item { background-color: var(--hover-color); margin-bottom: 1rem; border-radius: 5px; transition: transform 0.3s ease, box-shadow 0.3s ease; }
-        .post-list-item:hover { transform: translateY(-3px); box-shadow: 0 8px 20px rgba(0,0,0,0.3); }
-        .post-list-item a { display: block; padding: 1rem 1.5rem; color: var(--text-primary); text-decoration: none; font-weight: 500; }
-    </style>
+    <link rel="stylesheet" href="/assets/css/blog.css">
 </head>
 <body class="blog-page">
     <canvas id="transition-canvas"></canvas>
@@ -75,60 +53,111 @@
     </div>
 
     <main id="mainContainer" class="container blog-container show">
-        
-  <section class="section">
-    <p class="back"><a href="/blog/">← Voir tous les radars</a></p>
-    <h1 class="title">Radar PDM/PLM – 2025-09-19</h1>
-    <p class="meta">Veille du 19/09/2025 — PDM/PLM & écosystème.</p>
-    
-      <article class="post-item">
-        <h2 class="subtitle">
-          <a href="https://blogs.sw.siemens.com/teamcenter/configuring-products-to-order/" target="_blank" rel="noopener noreferrer">
-            Tech-Clarity: configuring products to order 🎯
-          </a>
-        </h2>
-        
-        <img src="https://blogs.sw.siemens.com/wp-content/uploads/sites/14/2025/09/GettyImages-1355368763-1024x683.jpg" alt="Tech-Clarity: configuring products to order 🎯">
-        
-        <p class="meta"><strong>Mots-clés:</strong> strong, https, com, siemens, blogs, wp-content</p>
-        <p class="meta"><strong>Catégories:</strong> PLM / Teamcenter</p>
-        
-        <p class="meta">Source : Teamcenter Blog (Siemens)</p>
-      </article>
-    
-      <article class="post-item">
-        <h2 class="subtitle">
-          <a href="https://blogs.solidworks.com/tech/2025/09/solidworks-backwards-compatibility.html" target="_blank" rel="noopener noreferrer">
-            SOLIDWORKS Backwards Compatibility
-          </a>
-        </h2>
-        
-        <img src="https://blog-assets.solidworks.com/uploads/sites/4/Picture3-9.png" alt="SOLIDWORKS Backwards Compatibility">
-        
-        <p class="meta"><strong>Mots-clés:</strong> solidworks, version, versions, https, com, blog-assets</p>
-        <p class="meta"><strong>Catégories:</strong> SolidWorks / Process / Release</p>
-        
-        <p class="meta">Source : SOLIDWORKS Tech Blog</p>
-      </article>
-    
-      <article class="post-item">
-        <h2 class="subtitle">
-          <a href="https://www.cimdata.com/en/education/educational-webinars/webinar-the-code-of-plm-openness-what-it-is-and-why-it-matters-now-more-than-ever" target="_blank" rel="noopener noreferrer">
-            The Code of PLM Openness – what it is and why it matters now more than ever!
-          </a>
-        </h2>
-        
-        
-        
-        <p class="meta"><strong>Mots-clés:</strong> plm, cimdata, systems, https, com, amp</p>
-        <p class="meta"><strong>Catégories:</strong> PLM / CIMdata</p>
-        
-        <p class="meta">Source : CIMdata Commentaries</p>
-      </article>
-    
-    <p class="back"><a href="/">← Retour au portfolio</a></p>
-  </section>
-
+        <div class="blog-shell" id="blogShell" data-shell>
+            <article class="blog-article" data-article-root><nav class="article-breadcrumbs" aria-label="Navigation secondaire">
+  <a class="back-link" href="/blog/">← Retour au blog</a>
+  <a class="back-link back-link--ghost" href="/">Retour au portfolio</a>
+</nav><header class="blog-hero post-hero" data-component="hero">
+  <div class="hero-intro">
+    <div class="hero-badges"><span class="badge badge-neutral">19/09/2025</span>
+      <span class="badge badge-radar">3 signaux</span></div>
+    <span class="hero-eyebrow">Radar quotidien</span>
+    <h1 class="hero-title">Radar PDM/PLM – 2025-09-19</h1>
+    <p class="hero-subtitle">Veille du 19 septembre 2025 — 3 signaux sélectionnés auprès de 3 sources.</p>
+    <div class="hero-actions"><a class="hero-btn" href="#sommaire">Consulter le sommaire</a>
+      <a class="hero-btn hero-btn--ghost" href="/#contact">Planifier un échange</a></div>
+  </div>
+  <div class="hero-stats">
+    <div class="hero-stat">
+      <span class="hero-stat-value">3</span>
+      <span class="hero-stat-label">Signaux sélectionnés</span>
+    </div>
+    <div class="hero-stat">
+      <span class="hero-stat-value">3</span>
+      <span class="hero-stat-label">Sources distinctes</span>
+    </div>
+    <div class="hero-stat">
+      <span class="hero-stat-value">19/09/2025</span>
+      <span class="hero-stat-label">Date de publication</span>
+    </div>
+  </div>
+</header><nav class="blog-section article-summary" id="sommaire" aria-label="Sommaire du radar">
+  <h2 class="summary-title">Sommaire</h2>
+  <ol class="summary-list">
+    <li>
+      <a href="#signal-01">
+        <span class="summary-index">01</span>
+        <span class="summary-label">Tech-Clarity: configuring products to order 🎯</span>
+        <span class="summary-meta">Teamcenter Blog (Siemens)</span>
+      </a>
+    </li>
+    <li>
+      <a href="#signal-02">
+        <span class="summary-index">02</span>
+        <span class="summary-label">SOLIDWORKS Backwards Compatibility</span>
+        <span class="summary-meta">SOLIDWORKS Tech Blog</span>
+      </a>
+    </li>
+    <li>
+      <a href="#signal-03">
+        <span class="summary-index">03</span>
+        <span class="summary-label">The Code of PLM Openness – why it matters</span>
+        <span class="summary-meta">CIMdata Commentaries</span>
+      </a>
+    </li>
+  </ol>
+</nav><section class="blog-section" data-component="radar-list">
+  <div class="section-header">
+    <div>
+      <h2>Les signaux du 19 septembre 2025</h2>
+      <p class="section-subtitle">Sélection automatisée de 3 liens issues de 3 sources.</p>
+    </div>
+    <span class="badge badge-radar">Radar</span>
+  </div>
+  <div class="card-grid radar-grid"><article class="post-card" data-entry-type="radar-item" id="signal-01" data-source="Teamcenter Blog (Siemens)">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Signal #1</span>
+    <span>Teamcenter Blog (Siemens)</span>
+  </div>
+  <h3 class="post-card__title">
+    <a href="https://blogs.sw.siemens.com/teamcenter/configuring-products-to-order/" target="_blank" rel="noopener noreferrer">Tech-Clarity: configuring products to order 🎯</a>
+  </h3>
+  <div class="post-card__enrichment"><div class="media-grid"><figure class="media-card"><img src="https://blogs.sw.siemens.com/wp-content/uploads/sites/14/2025/09/GettyImages-1355368763-1024x683.jpg" alt="Tech-Clarity: configuring products to order 🎯"></figure></div>
+    <div class="tag-list"><span class="tag">#strong</span><span class="tag">#https</span><span class="tag">#com</span><span class="tag">#siemens</span><span class="tag">#blogs</span><span class="tag">#wp-content</span></div>
+    <div class="tag-list"><span class="tag">PLM / Teamcenter</span></div></div>
+  <a class="post-card__cta" href="https://blogs.sw.siemens.com/teamcenter/configuring-products-to-order/" target="_blank" rel="noopener noreferrer">Ouvrir la source</a>
+</article><article class="post-card" data-entry-type="radar-item" id="signal-02" data-source="SOLIDWORKS Tech Blog">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Signal #2</span>
+    <span>SOLIDWORKS Tech Blog</span>
+  </div>
+  <h3 class="post-card__title">
+    <a href="https://blogs.solidworks.com/tech/2025/09/solidworks-backwards-compatibility.html" target="_blank" rel="noopener noreferrer">SOLIDWORKS Backwards Compatibility</a>
+  </h3>
+  <div class="post-card__enrichment"><div class="media-grid"><figure class="media-card"><img src="https://blog-assets.solidworks.com/uploads/sites/4/Picture3-9.png" alt="SOLIDWORKS Backwards Compatibility"></figure></div>
+    <div class="tag-list"><span class="tag">#solidworks</span><span class="tag">#version</span><span class="tag">#versions</span><span class="tag">#https</span><span class="tag">#com</span><span class="tag">#blog-assets</span></div>
+    <div class="tag-list"><span class="tag">SolidWorks / Process / Release</span></div></div>
+  <a class="post-card__cta" href="https://blogs.solidworks.com/tech/2025/09/solidworks-backwards-compatibility.html" target="_blank" rel="noopener noreferrer">Ouvrir la source</a>
+</article><article class="post-card" data-entry-type="radar-item" id="signal-03" data-source="CIMdata Commentaries">
+  <div class="post-card__meta">
+    <span class="badge badge-radar">Signal #3</span>
+    <span>CIMdata Commentaries</span>
+  </div>
+  <h3 class="post-card__title">
+    <a href="https://www.cimdata.com/en/education/educational-webinars/webinar-the-code-of-plm-openness-what-it-is-and-why-it-matters-now-more-than-ever" target="_blank" rel="noopener noreferrer">The Code of PLM Openness – what it is and why it matters now more than ever!</a>
+  </h3>
+  <div class="post-card__enrichment"><div class="tag-list"><span class="tag">#plm</span><span class="tag">#cimdata</span><span class="tag">#systems</span><span class="tag">#https</span><span class="tag">#com</span><span class="tag">#amp</span></div>
+    <div class="tag-list"><span class="tag">PLM / CIMdata</span></div></div>
+  <a class="post-card__cta" href="https://www.cimdata.com/en/education/educational-webinars/webinar-the-code-of-plm-openness-what-it-is-and-why-it-matters-now-more-than-ever" target="_blank" rel="noopener noreferrer">Ouvrir la source</a>
+</article></div>
+</section><section class="blog-section article-cta" data-component="cta">
+  <div class="cta-card">
+    <h2>Aller plus loin avec votre veille PLM</h2>
+    <p>Envie d'automatiser votre radar ou de structurer votre démarche de veille ? Parlons-en.</p>
+    <a class="hero-btn" href="/#contact">Planifier un échange</a>
+  </div>
+</section></article>
+        </div>
     </main>
 
     <footer>
@@ -142,7 +171,7 @@
             </div>
         </div>
     </footer>
-    
+
     <div class="ai-assistant-fab" id="ai-fab">
         </div>
     <div class="ai-fab-notification" id="ai-fab-notification"></div>
@@ -150,5 +179,6 @@
         </div>
 
     <script src="/assets/js/script.js"></script>
+    <script type="module" src="/assets/js/blog.js"></script>
 </body>
 </html>

--- a/blog/radar-2025-09-21/index.html
+++ b/blog/radar-2025-09-21/index.html
@@ -10,28 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Radar PDM/PLM – 2025-09-21</title> <meta name="description" content="Aucune actualité aujourd&#39;hui.">
     <link rel="stylesheet" href="/assets/css/style.css">
-    <style>
-        /* Styles spécifiques au blog, que vous aviez dans les fichiers générés */
-        .blog-container { max-width: 900px; margin: 120px auto 40px !important; padding: 20px; }
-        .section { background-color: var(--bg-secondary); border-radius: 10px; padding: 2rem 3rem; box-shadow: 0 15px 35px rgba(0,0,0,0.3); border: 1px solid var(--bg-tertiary); }
-        .title { font-size: 2.5rem; color: var(--accent-primary); margin-bottom: 0.5rem; border-bottom: 2px solid var(--accent-secondary); padding-bottom: 0.5rem; display: inline-block; }
-        .meta { color: var(--text-secondary); margin-bottom: 2.5rem; font-style: italic; }
-        .post-item { border-bottom: 1px solid var(--bg-tertiary); padding: 1.5rem 0; transition: background-color 0.3s ease; margin: 0 -3rem; padding: 1.5rem 3rem; }
-        .post-item:last-child { border-bottom: none; }
-        .post-item:hover { background-color: var(--hover-color); }
-        .subtitle { margin: 0 0 0.5rem 0; font-size: 1.25rem; }
-        .subtitle a { color: var(--text-primary); text-decoration: none; transition: color 0.3s; }
-        .subtitle a:hover { color: var(--accent-primary); }
-        .post-item .meta { font-size: 0.85rem; margin-bottom: 0.5rem; color: var(--text-secondary); }
-        .post-item img { max-width: 100%; border-radius: 5px; margin-top: 1rem; margin-bottom: 0.5rem; }
-        .back { margin-top: 2rem; }
-        .back a { color: var(--accent-secondary); font-weight: 500; text-decoration: none; transition: color 0.3s; }
-        .back a:hover { color: var(--accent-primary); }
-        .post-list { list-style: none; padding: 0; }
-        .post-list-item { background-color: var(--hover-color); margin-bottom: 1rem; border-radius: 5px; transition: transform 0.3s ease, box-shadow 0.3s ease; }
-        .post-list-item:hover { transform: translateY(-3px); box-shadow: 0 8px 20px rgba(0,0,0,0.3); }
-        .post-list-item a { display: block; padding: 1rem 1.5rem; color: var(--text-primary); text-decoration: none; font-weight: 500; }
-    </style>
+    <link rel="stylesheet" href="/assets/css/blog.css">
 </head>
 <body class="blog-page">
     <canvas id="transition-canvas"></canvas>
@@ -75,14 +54,47 @@
     </div>
 
     <main id="mainContainer" class="container blog-container show">
-        
-  <section class="section">
-    <p class="back"><a href="/blog/">← Voir tous les radars</a></p>
-    <h1 class="title">Radar PDM/PLM – 2025-09-21</h1>
-    <p class="meta">Aucune actualité aujourd'hui.</p>
-    <p class="back"><a href="/">← Retour au portfolio</a></p>
-  </section>
-
+        <div class="blog-shell" id="blogShell" data-shell>
+            <article class="blog-article" data-article-root><nav class="article-breadcrumbs" aria-label="Navigation secondaire">
+  <a class="back-link" href="/blog/">← Retour au blog</a>
+  <a class="back-link back-link--ghost" href="/">Retour au portfolio</a>
+</nav><header class="blog-hero post-hero" data-component="hero">
+  <div class="hero-intro">
+    <div class="hero-badges"><span class="badge badge-neutral">21/09/2025</span>
+      <span class="badge badge-radar">0 signaux</span></div>
+    <span class="hero-eyebrow">Radar quotidien</span>
+    <h1 class="hero-title">Radar PDM/PLM – 2025-09-21</h1>
+    <p class="hero-subtitle">Aucune actualité détectée pour le 21 septembre 2025.</p>
+    <div class="hero-actions"><a class="hero-btn" href="/blog/">← Tous les radars</a>
+      <a class="hero-btn hero-btn--ghost" href="/#contact">Planifier un échange</a></div>
+  </div>
+  <div class="hero-stats">
+    <div class="hero-stat">
+      <span class="hero-stat-value">0</span>
+      <span class="hero-stat-label">Signaux sélectionnés</span>
+    </div>
+    <div class="hero-stat">
+      <span class="hero-stat-value">0</span>
+      <span class="hero-stat-label">Sources distinctes</span>
+    </div>
+    <div class="hero-stat">
+      <span class="hero-stat-value">21/09/2025</span>
+      <span class="hero-stat-label">Date de publication</span>
+    </div>
+  </div>
+  
+</header><section class="blog-section" data-component="radar-empty">
+  <div class="empty-state">
+    <p>Aucun signal détecté aujourd&#39;hui. Revenez demain pour une nouvelle veille.</p>
+  </div>
+</section><section class="blog-section article-cta" data-component="cta">
+  <div class="cta-card">
+    <h2>Aller plus loin avec votre veille PLM</h2>
+    <p>Envie d'automatiser votre radar ou de structurer votre démarche de veille ? Parlons-en.</p>
+    <a class="hero-btn" href="/#contact">Planifier un échange</a>
+  </div>
+</section></article>
+        </div>
     </main>
 
     <footer>
@@ -104,5 +116,6 @@
         </div>
 
     <script src="/assets/js/script.js"></script>
+    <script type="module" src="/assets/js/blog.js"></script>
 </body>
 </html>

--- a/blog/resolutions-problematiques-plm/index.html
+++ b/blog/resolutions-problematiques-plm/index.html
@@ -11,15 +11,7 @@
     <title>Au-delà de la théorie : résoudre les 5 problématiques PLM que j'ai vécues en tant qu'Ingénieur Mécanique</title>
     <meta name="description" content="Retour d'expérience de Mohamed Omar Baouch sur cinq problématiques PLM vécues sur le terrain et les solutions apportées grâce à un PDM/PLM bien implémenté.">
     <link rel="stylesheet" href="/assets/css/style.css">
-    <style>
-        .blog-container { max-width: 900px; margin: 120px auto 40px !important; padding: 20px; }
-        .section { background-color: var(--bg-secondary); border-radius: 10px; padding: 2rem 3rem; box-shadow: 0 15px 35px rgba(0,0,0,0.3); border: 1px solid var(--bg-tertiary); }
-        .title { font-size: 2.5rem; color: var(--accent-primary); margin-bottom: 0.5rem; border-bottom: 2px solid var(--accent-secondary); padding-bottom: 0.5rem; display: inline-block; }
-        .meta { color: var(--text-secondary); margin-bottom: 2.5rem; font-style: italic; }
-        .back { margin-top: 2rem; }
-        .back a { color: var(--accent-secondary); font-weight: 500; text-decoration: none; transition: color 0.3s; }
-        .back a:hover { color: var(--accent-primary); }
-    </style>
+    <link rel="stylesheet" href="/assets/css/blog.css">
 </head>
 <body class="blog-page">
     <canvas id="transition-canvas"></canvas>
@@ -62,24 +54,194 @@
     </div>
 
     <main id="mainContainer" class="container blog-container show">
-        <section class="section">
-            <p class="back"><a href="/blog/">← Voir tous les radars</a></p>
-            <h1 class="title">Au-delà de la théorie : résoudre les 5 problématiques PLM que j'ai vécues en tant qu'Ingénieur Mécanique</h1>
-            <p class="meta">Par Mohamed Omar Baouch – 15/09/2025</p>
-            <p>Quand j'ai débuté comme ingénieur mécanique, la gestion des données produit me semblait un sujet réservé aux grandes entreprises et aux théoriciens des processus. La réalité du terrain m'a vite montré l'inverse. Chez Evolum puis chez ABMI, j'ai vu comment un simple plan mal versionné pouvait immobiliser une ligne de production ou comment une nomenclature erronée pouvait faire exploser les coûts d'un projet. Ces expériences m'ont donné une conviction : un PDM/PLM bien implémenté n'est pas un luxe mais une condition de survie pour toute organisation industrielle.</p>
-            <h2>1. Silos de données qui fragmentent le savoir</h2>
-            <p>À mes débuts chez Evolum, chacun travaillait dans son coin. Les fichiers de conception étaient dispersés entre des disques partagés, des clés USB et parfois des ordinateurs personnels. Lorsque je devais reprendre un projet, je passais plus de temps à chercher la bonne version d'un assemblage qu'à concevoir. Cette fragmentation du savoir faisait perdre un temps précieux et créait des divergences entre les bureaux d'études et l'atelier. La mise en place d'un coffre-fort PDM centralisé a été une révélation : chaque modèle était stocké une seule fois, les droits d'accès étaient clairs et je pouvais retracer l'historique complet d'une pièce sans lever de téléphone.</p>
-            <h2>2. Erreurs dans les nomenclatures</h2>
-            <p>Lors d'une mission chez ABMI, j'ai vécu les conséquences d'une nomenclature gérée sous Excel. Une ligne oubliée a entraîné l'achat de pièces supplémentaires et plusieurs jours de retard sur un prototype. C'est à ce moment que j'ai compris l'importance d'un système PLM capable de générer des nomenclatures cohérentes directement depuis la CAO et de les lier aux achats. Avec SolidWorks PDM, nous avons automatisé l'extraction des BOM et mis en place des règles de validation qui ont supprimé ce type d'erreurs. L'équipe projet gagnait en sérénité et les réunions ne tournaient plus autour de la question « qui possède la bonne version ? ».</p>
-            <h2>3. Versions incontrôlées et confusion</h2>
-            <p>Avant d'adopter un PDM, la gestion des révisions se résumait à des suffixes dans les noms de fichiers. Il n'était pas rare de voir des dossiers remplis de "finale", "finale2" ou "version_definitive_v3". Lors de mon passage chez Evolum, cette pratique a provoqué la fabrication d'un lot de pièces basé sur un plan obsolète. En implémentant un véritable PLM chez Visiativ, j'ai découvert la puissance du contrôle de versions : chaque modification est tracée, commentée et validée. Les transitions de statuts (en conception, en validation, publié) ont apporté une clarté immédiate et réduit les allers-retours improductifs.</p>
-            <h2>4. Collaboration freinée entre bureaux d'études et production</h2>
-            <p>La collaboration se limitait souvent à l'échange de fichiers par email. Les retours de l'atelier arrivaient tard et les remarques se perdaient dans les boîtes de réception. En tant que consultant chez Visiativ, j'ai accompagné plusieurs clients dans l'intégration de workflows qui relient directement la conception à la production. Grâce à un PDM bien configuré, l'atelier peut annoter les modèles, proposer des modifications et suivre leur prise en compte. Cette boucle de feedback en continu a transformé la relation entre les équipes et réduit drastiquement les erreurs de fabrication.</p>
-            <h2>5. Traçabilité et conformité</h2>
-            <p>Dans des secteurs réglementés, prouver la conformité d'un produit est aussi important que le produit lui-même. Avant l'arrivée d'un PLM, la traçabilité reposait sur des dossiers papier et la mémoire des ingénieurs. J'ai vu un audit repoussé parce qu'il était impossible de démontrer la généalogie complète d'un composant. Avec un PLM, chaque décision, chaque validation et chaque version est enregistrée. Lors d'un projet piloté par Visiativ, nous avons pu répondre à un audit en quelques clics, fournissant l'historique complet des modifications d'une pièce critique. La confiance du client s'en est trouvée renforcée.</p>
-            <p>Ces cinq problématiques ne sont pas de simples cas d'école. Elles ont freiné des projets auxquels j'ai participé et m'ont parfois laissé un goût d'inachevé. Aujourd'hui, en tant que consultant PDM/PLM chez Visiativ, je mets cette expérience au service des entreprises qui veulent éviter ces pièges. Un PDM/PLM bien implémenté apporte de la rigueur sans étouffer la créativité : il libère les équipes de la chasse aux informations pour qu'elles se concentrent sur l'innovation. Si ces retours d'expérience résonnent avec vos propres défis, discutons-en. Je suis convaincu que la transformation commence par un diagnostic honnête du terrain, bien avant les slides de présentation.</p>
-            <p class="back"><a href="/">← Retour au portfolio</a></p>
-        </section>
+        <div class="blog-shell" id="blogShell" data-shell>
+            <article class="blog-article" data-article-root>
+                <nav class="article-breadcrumbs" aria-label="Navigation secondaire">
+                    <a class="back-link" href="/blog/">← Retour au blog</a>
+                    <a class="back-link back-link--ghost" href="/">Retour au portfolio</a>
+                </nav>
+
+                <header class="blog-hero post-hero" data-component="hero">
+                    <div class="hero-intro">
+                        <div class="hero-badges">
+                            <span class="badge badge-editorial">Article de fond</span>
+                        </div>
+                        <span class="hero-eyebrow">Expérience terrain</span>
+                        <h1 class="hero-title">Au-delà de la théorie : résoudre les 5 problématiques PLM que j'ai vécues en tant qu'Ingénieur Mécanique</h1>
+                        <p class="hero-subtitle">Retour d'expérience publié le 15 septembre 2025 : comment passer des discours aux actions concrètes pour sécuriser données, nomenclatures et collaboration.</p>
+                        <div class="hero-actions">
+                            <a class="hero-btn" href="#sommaire">Consulter le sommaire</a>
+                            <a class="hero-btn hero-btn--ghost" href="/#contact">Discuter de votre projet</a>
+                        </div>
+                    </div>
+                    <div class="hero-stats">
+                        <div class="hero-stat">
+                            <span class="hero-stat-value">15/09/2025</span>
+                            <span class="hero-stat-label">Date de publication</span>
+                        </div>
+                        <div class="hero-stat">
+                            <span class="hero-stat-value">5</span>
+                            <span class="hero-stat-label">Problématiques traitées</span>
+                        </div>
+                        <div class="hero-stat">
+                            <span class="hero-stat-value">Visiativ</span>
+                            <span class="hero-stat-label">Expertise terrain</span>
+                        </div>
+                    </div>
+                </header>
+
+                <nav class="blog-section article-summary" id="sommaire" aria-label="Sommaire de l'article">
+                    <h2 class="summary-title">Sommaire</h2>
+                    <ol class="summary-list">
+                        <li>
+                            <a href="#silos-donnees">
+                                <span class="summary-index">01</span>
+                                <span class="summary-label">Silos de données qui fragmentent le savoir</span>
+                                <span class="summary-meta">De l'enquête manuelle au coffre-fort PDM</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#erreurs-nomenclatures">
+                                <span class="summary-index">02</span>
+                                <span class="summary-label">Erreurs dans les nomenclatures</span>
+                                <span class="summary-meta">Quand Excel fait dérailler la production</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#versions-incontrolees">
+                                <span class="summary-index">03</span>
+                                <span class="summary-label">Versions incontrôlées et confusion</span>
+                                <span class="summary-meta">Le risque caché des dossiers « finale_v3 »</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#collaboration-freinee">
+                                <span class="summary-index">04</span>
+                                <span class="summary-label">Collaboration freinée entre BE et production</span>
+                                <span class="summary-meta">Du mail perdu au workflow tracé</span>
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#tracabilite-conformite">
+                                <span class="summary-index">05</span>
+                                <span class="summary-label">Traçabilité et conformité sous tension</span>
+                                <span class="summary-meta">Répondre à un audit en quelques clics</span>
+                            </a>
+                        </li>
+                    </ol>
+                </nav>
+
+                <section class="blog-section article-section">
+                    <p>Quand j'ai débuté comme ingénieur mécanique, la gestion des données produit me semblait un sujet réservé aux grandes entreprises et aux théoriciens des processus. La réalité du terrain m'a vite montré l'inverse. Chez Evolum puis chez ABMI, j'ai vu comment un simple plan mal versionné pouvait immobiliser une ligne de production ou comment une nomenclature erronée pouvait faire exploser les coûts d'un projet.</p>
+                    <div class="callout">
+                        <div class="quote-block">
+                            <blockquote>Un PDM/PLM bien implémenté n'est pas un luxe : c'est un filet de sécurité qui libère les équipes de la chasse aux informations pour qu'elles se concentrent sur l'innovation.</blockquote>
+                            <cite>Mohamed Omar Baouch</cite>
+                        </div>
+                    </div>
+                    <p>Au fil des projets, j'ai identifié cinq problématiques récurrentes. Elles ne sont pas théoriques : chacune est issue d'un incident concret, d'un retard de production ou d'un audit stressant. Voici la synthèse des symptômes et des réponses mises en place avec les équipes terrain.</p>
+                    <table class="feature-table">
+                        <thead>
+                            <tr>
+                                <th>Problématique</th>
+                                <th>Impact terrain</th>
+                                <th>Solution PLM appliquée</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>Silos de données</td>
+                                <td>Temps perdu à retrouver la bonne version</td>
+                                <td>Coffre-fort PDM centralisé et droits maîtrisés</td>
+                            </tr>
+                            <tr>
+                                <td>Nomenclatures instables</td>
+                                <td>Achats erronés, prototypes retardés</td>
+                                <td>Génération automatique des BOM depuis la CAO</td>
+                            </tr>
+                            <tr>
+                                <td>Versions incontrôlées</td>
+                                <td>Production lancée sur un plan obsolète</td>
+                                <td>Gestion des révisions et workflow de validation</td>
+                            </tr>
+                            <tr>
+                                <td>Collaboration freinée</td>
+                                <td>Feedback perdu entre mail et atelier</td>
+                                <td>Workflows intégrés entre BE et production</td>
+                            </tr>
+                            <tr>
+                                <td>Traçabilité fragile</td>
+                                <td>Audits retardés, confiance client fragilisée</td>
+                                <td>Historique complet et généalogie des pièces</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
+
+                <section class="blog-section article-section" id="silos-donnees">
+                    <h2>1. Silos de données qui fragmentent le savoir</h2>
+                    <p>À mes débuts chez Evolum, chacun travaillait dans son coin. Les fichiers de conception étaient dispersés entre des disques partagés, des clés USB et parfois des ordinateurs personnels. Lorsque je devais reprendre un projet, je passais plus de temps à chercher la bonne version d'un assemblage qu'à concevoir.</p>
+                    <p>Cette fragmentation du savoir faisait perdre un temps précieux et créait des divergences entre les bureaux d'études et l'atelier. La mise en place d'un coffre-fort PDM centralisé a été une révélation : chaque modèle était stocké une seule fois, les droits d'accès étaient clairs et je pouvais retracer l'historique complet d'une pièce sans lever de téléphone.</p>
+                    <div class="callout callout--soft">
+                        <p><strong>Clé du succès :</strong> rendre le PDM incontournable en l'intégrant dans les habitudes quotidiennes (check-in/check-out, commentaires, workflows de revue).</p>
+                    </div>
+                </section>
+
+                <section class="blog-section article-section" id="erreurs-nomenclatures">
+                    <h2>2. Erreurs dans les nomenclatures</h2>
+                    <p>Lors d'une mission chez ABMI, j'ai vécu les conséquences d'une nomenclature gérée sous Excel. Une ligne oubliée a entraîné l'achat de pièces supplémentaires et plusieurs jours de retard sur un prototype. C'est à ce moment que j'ai compris l'importance d'un système PLM capable de générer des nomenclatures cohérentes directement depuis la CAO et de les lier aux achats.</p>
+                    <div class="media-grid">
+                        <div class="media-card media-card--text">
+                            <h3>Avant</h3>
+                            <ul>
+                                <li>Excel partagé par mail</li>
+                                <li>Versions multiples sans historique</li>
+                                <li>Décisions prises hors système</li>
+                            </ul>
+                        </div>
+                        <div class="media-card media-card--text">
+                            <h3>Après</h3>
+                            <ul>
+                                <li>BOM générée automatiquement</li>
+                                <li>Validation croisée avec les achats</li>
+                                <li>Historique des modifications consolidé</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <p>Avec SolidWorks PDM, nous avons automatisé l'extraction des BOM et mis en place des règles de validation qui ont supprimé ce type d'erreurs. L'équipe projet gagnait en sérénité et les réunions ne tournaient plus autour de la question « qui possède la bonne version ? ».</p>
+                </section>
+
+                <section class="blog-section article-section" id="versions-incontrolees">
+                    <h2>3. Versions incontrôlées et confusion</h2>
+                    <p>Avant d'adopter un PDM, la gestion des révisions se résumait à des suffixes dans les noms de fichiers. Il n'était pas rare de voir des dossiers remplis de "finale", "finale2" ou "version_definitive_v3". Lors de mon passage chez Evolum, cette pratique a provoqué la fabrication d'un lot de pièces basé sur un plan obsolète.</p>
+                    <p>En implémentant un véritable PLM chez Visiativ, j'ai découvert la puissance du contrôle de versions : chaque modification est tracée, commentée et validée. Les transitions de statuts (en conception, en validation, publié) ont apporté une clarté immédiate et réduit drastiquement les allers-retours improductifs.</p>
+                </section>
+
+                <section class="blog-section article-section" id="collaboration-freinee">
+                    <h2>4. Collaboration freinée entre bureaux d'études et production</h2>
+                    <p>La collaboration se limitait souvent à l'échange de fichiers par email. Les retours de l'atelier arrivaient tard et les remarques se perdaient dans les boîtes de réception. En tant que consultant chez Visiativ, j'ai accompagné plusieurs clients dans l'intégration de workflows qui relient directement la conception à la production.</p>
+                    <p>Grâce à un PDM bien configuré, l'atelier peut annoter les modèles, proposer des modifications et suivre leur prise en compte. Cette boucle de feedback en continu a transformé la relation entre les équipes et réduit drastiquement les erreurs de fabrication.</p>
+                </section>
+
+                <section class="blog-section article-section" id="tracabilite-conformite">
+                    <h2>5. Traçabilité et conformité</h2>
+                    <p>Dans des secteurs réglementés, prouver la conformité d'un produit est aussi important que le produit lui-même. Avant l'arrivée d'un PLM, la traçabilité reposait sur des dossiers papier et la mémoire des ingénieurs. J'ai vu un audit repoussé parce qu'il était impossible de démontrer la généalogie complète d'un composant.</p>
+                    <p>Avec un PLM, chaque décision, chaque validation et chaque version est enregistrée. Lors d'un projet piloté par Visiativ, nous avons pu répondre à un audit en quelques clics, fournissant l'historique complet des modifications d'une pièce critique. La confiance du client s'en est trouvée renforcée.</p>
+                </section>
+
+                <section class="blog-section article-section">
+                    <p>Ces cinq problématiques ne sont pas de simples cas d'école. Elles ont freiné des projets auxquels j'ai participé et m'ont parfois laissé un goût d'inachevé. Aujourd'hui, en tant que consultant PDM/PLM chez Visiativ, je mets cette expérience au service des entreprises qui veulent éviter ces pièges.</p>
+                </section>
+
+                <section class="blog-section article-cta" data-component="cta">
+                    <div class="cta-card">
+                        <h2>Envie de résoudre vos problématiques PLM&nbsp;?</h2>
+                        <p>Construisons ensemble une feuille de route pragmatique, ancrée dans votre réalité terrain. Une simple discussion peut révéler les priorités à adresser en premier.</p>
+                        <a class="hero-btn" href="/#contact">Planifier un échange</a>
+                    </div>
+                </section>
+            </article>
+        </div>
     </main>
 
     <footer>
@@ -99,5 +261,6 @@
     <div class="ai-assistant-container" id="ai-container"></div>
 
     <script src="/assets/js/script.js"></script>
+    <script type="module" src="/assets/js/blog.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- overhaul blog template to expose navigation, hero, summary, content, sidebar and footer slots
- extend blog stylesheet with reusable hero badges, summaries, media grids, callouts and CTA styles for posts
- refactor radar generation to use new components, add navigation, summaries and CTA sections, and refresh the editorial article layout

## Testing
- npm run build-blog

------
https://chatgpt.com/codex/tasks/task_e_68cffa950db4832f8f3c0af834446953