### PR TITLE
Improve blog mobile layout

### DIFF
--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -250,6 +250,7 @@
     border-collapse: collapse;
     margin: 1.5rem 0;
     font-size: 0.95rem;
+    table-layout: fixed;
 }
 
 .feature-table th,
@@ -257,6 +258,7 @@
     border: 1px solid rgba(255, 255, 255, 0.08);
     padding: 0.9rem 1rem;
     text-align: left;
+    word-break: break-word;
 }
 
 .feature-table thead {
@@ -471,7 +473,7 @@
 .card-grid {
     display: grid;
     gap: 1.5rem;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr));
 }
 
 .post-card {
@@ -733,5 +735,45 @@
     .section-header {
         flex-direction: column;
         align-items: flex-start;
+    }
+
+    .blog-container {
+        padding: 0 1.25rem 3rem;
+    }
+
+    .blog-hero {
+        padding: 2.25rem 1.5rem;
+        grid-template-columns: 1fr;
+        gap: 1.75rem;
+    }
+
+    .post-hero {
+        grid-template-columns: 1fr;
+    }
+
+    .feature-table th,
+    .feature-table td {
+        padding: 0.75rem 0.85rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .blog-container {
+        padding: 0 1rem 2.5rem;
+    }
+
+    .blog-hero {
+        padding: 1.85rem 1.25rem;
+        gap: 1.5rem;
+    }
+
+    .card-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .feature-table th,
+    .feature-table td {
+        padding: 0.65rem 0.75rem;
+        font-size: 0.9rem;
     }
 }


### PR DESCRIPTION
## Summary
- adjust blog container and hero paddings at 640px and 480px to optimise mobile spacing and force a single hero column
- shrink the blog card grid column minimum and collapse it to one column on very small screens to prevent horizontal overflow
- enable tables to wrap content and reduce cell padding on narrow devices for better readability

## Testing
- playwright mobile layout check (custom script)


------
https://chatgpt.com/codex/tasks/task_e_68d0fdaefc94832f822a7ca5c1637a1a