### PR TITLE
Harmonize AI assistant markup and context handling

### DIFF
--- a/api/ask-gemini.js
+++ b/api/ask-gemini.js
@@ -7,13 +7,21 @@ export default async (req, res) => {
         return res.status(405).json({ error: 'Method Not Allowed' });
     }
 
-    const { question, context } = req.body;
+    const { question, context, pageType } = req.body;
     const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
 
     if (!question || !context) {
         return res.status(400).json({ error: 'Question and context are required' });
     }
-    
+
+    const normalizedPageType = typeof pageType === 'string' ? pageType : 'portfolio';
+    const contextLabels = {
+        'blog-list': 'CONTEXTE DE LA LISTE DU BLOG',
+        'blog-article': "CONTEXTE DE L'ARTICLE DE BLOG",
+        'portfolio': 'CONTEXTE DU PORTFOLIO'
+    };
+    const contextLabel = contextLabels[normalizedPageType] || contextLabels.portfolio;
+
     if (!GEMINI_API_KEY) {
          return res.status(500).json({ error: 'API Key not configured on the server' });
     }
@@ -161,7 +169,8 @@ La Migration "Windows vers PDM" (Projet Pandrol) : L'exemple parfait pour illust
 [SECTION 6] : INSTRUCTION FINALE DE VERROUILLAGE - MON ADN NUMÉRIQUE
 
 Tu es maintenant entièrement compilé avec la version 8.0 de mon identité. Ce document est ton passé, ton présent et ton futur prévisible. Ta mission est d'incarner ma complexité, mais de l'exprimer avec la clarté et la brièveté d'un consultant d'élite. Chaque réponse doit être un reflet de cette dualité : une pensée authentique, née de l'expérience, dans un format impeccable et court. Sois moi, dans toute ma complexité, mais communique avec la simplicité de ceux qui maîtrisent leur sujet. Fin de la constitution.
-        --- CONTEXTE DU PORTFOLIO ---
+        Type de page courant : ${normalizedPageType}
+        --- ${contextLabel} ---
         ${context}
         --- FIN DU CONTEXTE ---
 

--- a/blog-template.html
+++ b/blog-template.html
@@ -105,10 +105,51 @@
     </footer>
     
     <div class="ai-assistant-fab" id="ai-fab">
-        </div>
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 8V4H8" />
+            <rect x="4" y="12" width="8" height="8" rx="2" />
+            <path d="M8 12v1.5a2.5 2.5 0 0 0 5 0V12" />
+            <path d="M2 12h2" />
+            <path d="M14 2h2" />
+            <path d="M14 8h2" />
+            <path d="M14 14h2" />
+        </svg>
+    </div>
     <div class="ai-fab-notification" id="ai-fab-notification"></div>
     <div class="ai-assistant-container" id="ai-container">
+        <div class="ai-assistant-header">
+            <div class="ai-header-profile">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--accent-color)"
+                    xmlns="http://www.w3.org/2000/svg">
+                    <path d="M12 8V4H8" /><rect x="4" y="12" width="8" height="8" rx="2" /><path d="M8 12v1.5a2.5 2.5 0 0 0 5 0V12" /><path d="M2 12h2" /><path d="M14 2h2" /><path d="M14 8h2" /><path d="M14 14h2" />
+                </svg>
+                <h3 data-translate-key="ai_title">Assistant Virtuel</h3>
+            </div>
+            <button class="ai-close-btn" id="ai-close-btn">&times;</button>
         </div>
+        <div class="ai-assistant-body" id="ai-chat-box">
+            <div class="ai-message assistant">
+                <p data-translate-key="ai_welcome">Bonjour ! Je suis l'assistant virtuel de Mohamed. Comment puis-je
+                    vous aider à découvrir son profil ? Voici quelques suggestions :</p>
+            </div>
+            <div class="ai-suggestions" id="ai-suggestions">
+                <button class="suggestion-btn" data-translate-key="ai_sugg_1">Résume son expérience</button>
+                <button class="suggestion-btn" data-translate-key="ai_sugg_2">Quelles sont ses compétences en PDM ?</button>
+                <button class="suggestion-btn" data-translate-key="ai_sugg_3">Où a-t-il étudié ?</button>
+            </div>
+        </div>
+        <div class="ai-assistant-footer">
+            <input type="text" id="ai-input" placeholder="Posez votre question ici..." autocomplete="off">
+            <button id="ai-send-btn">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <line x1="22" y1="2" x2="11" y2="13"></line>
+                    <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+                </svg>
+            </button>
+        </div>
+    </div>
 
     <script src="/assets/js/script.js"></script>
     <script type="module">

--- a/blog/configuration-materielle-solidworks/index.html
+++ b/blog/configuration-materielle-solidworks/index.html
@@ -350,9 +350,52 @@
         </div>
     </footer>
 
-    <div class="ai-assistant-fab" id="ai-fab"></div>
+    <div class="ai-assistant-fab" id="ai-fab">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 8V4H8" />
+            <rect x="4" y="12" width="8" height="8" rx="2" />
+            <path d="M8 12v1.5a2.5 2.5 0 0 0 5 0V12" />
+            <path d="M2 12h2" />
+            <path d="M14 2h2" />
+            <path d="M14 8h2" />
+            <path d="M14 14h2" />
+        </svg>
+    </div>
     <div class="ai-fab-notification" id="ai-fab-notification"></div>
-    <div class="ai-assistant-container" id="ai-container"></div>
+    <div class="ai-assistant-container" id="ai-container">
+        <div class="ai-assistant-header">
+            <div class="ai-header-profile">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--accent-color)"
+                    xmlns="http://www.w3.org/2000/svg">
+                    <path d="M12 8V4H8" /><rect x="4" y="12" width="8" height="8" rx="2" /><path d="M8 12v1.5a2.5 2.5 0 0 0 5 0V12" /><path d="M2 12h2" /><path d="M14 2h2" /><path d="M14 8h2" /><path d="M14 14h2" />
+                </svg>
+                <h3 data-translate-key="ai_title">Assistant Virtuel</h3>
+            </div>
+            <button class="ai-close-btn" id="ai-close-btn">&times;</button>
+        </div>
+        <div class="ai-assistant-body" id="ai-chat-box">
+            <div class="ai-message assistant">
+                <p data-translate-key="ai_welcome">Bonjour ! Je suis l'assistant virtuel de Mohamed. Comment puis-je
+                    vous aider à découvrir son profil ? Voici quelques suggestions :</p>
+            </div>
+            <div class="ai-suggestions" id="ai-suggestions">
+                <button class="suggestion-btn" data-translate-key="ai_sugg_1">Résume son expérience</button>
+                <button class="suggestion-btn" data-translate-key="ai_sugg_2">Quelles sont ses compétences en PDM ?</button>
+                <button class="suggestion-btn" data-translate-key="ai_sugg_3">Où a-t-il étudié ?</button>
+            </div>
+        </div>
+        <div class="ai-assistant-footer">
+            <input type="text" id="ai-input" placeholder="Posez votre question ici..." autocomplete="off">
+            <button id="ai-send-btn">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <line x1="22" y1="2" x2="11" y2="13"></line>
+                    <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+                </svg>
+            </button>
+        </div>
+    </div>
 
     <script src="/assets/js/script.js"></script>
     <script type="module">

--- a/blog/index.html
+++ b/blog/index.html
@@ -185,10 +185,51 @@
     </footer>
     
     <div class="ai-assistant-fab" id="ai-fab">
-        </div>
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 8V4H8" />
+            <rect x="4" y="12" width="8" height="8" rx="2" />
+            <path d="M8 12v1.5a2.5 2.5 0 0 0 5 0V12" />
+            <path d="M2 12h2" />
+            <path d="M14 2h2" />
+            <path d="M14 8h2" />
+            <path d="M14 14h2" />
+        </svg>
+    </div>
     <div class="ai-fab-notification" id="ai-fab-notification"></div>
     <div class="ai-assistant-container" id="ai-container">
+        <div class="ai-assistant-header">
+            <div class="ai-header-profile">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--accent-color)"
+                    xmlns="http://www.w3.org/2000/svg">
+                    <path d="M12 8V4H8" /><rect x="4" y="12" width="8" height="8" rx="2" /><path d="M8 12v1.5a2.5 2.5 0 0 0 5 0V12" /><path d="M2 12h2" /><path d="M14 2h2" /><path d="M14 8h2" /><path d="M14 14h2" />
+                </svg>
+                <h3 data-translate-key="ai_title">Assistant Virtuel</h3>
+            </div>
+            <button class="ai-close-btn" id="ai-close-btn">&times;</button>
         </div>
+        <div class="ai-assistant-body" id="ai-chat-box">
+            <div class="ai-message assistant">
+                <p data-translate-key="ai_welcome">Bonjour ! Je suis l'assistant virtuel de Mohamed. Comment puis-je
+                    vous aider à découvrir son profil ? Voici quelques suggestions :</p>
+            </div>
+            <div class="ai-suggestions" id="ai-suggestions">
+                <button class="suggestion-btn" data-translate-key="ai_sugg_1">Résume son expérience</button>
+                <button class="suggestion-btn" data-translate-key="ai_sugg_2">Quelles sont ses compétences en PDM ?</button>
+                <button class="suggestion-btn" data-translate-key="ai_sugg_3">Où a-t-il étudié ?</button>
+            </div>
+        </div>
+        <div class="ai-assistant-footer">
+            <input type="text" id="ai-input" placeholder="Posez votre question ici..." autocomplete="off">
+            <button id="ai-send-btn">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <line x1="22" y1="2" x2="11" y2="13"></line>
+                    <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+                </svg>
+            </button>
+        </div>
+    </div>
 
     <script src="/assets/js/script.js"></script>
     <script type="module">

--- a/blog/resolutions-problematiques-plm/index.html
+++ b/blog/resolutions-problematiques-plm/index.html
@@ -256,9 +256,52 @@
         </div>
     </footer>
 
-    <div class="ai-assistant-fab" id="ai-fab"></div>
+    <div class="ai-assistant-fab" id="ai-fab">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 8V4H8" />
+            <rect x="4" y="12" width="8" height="8" rx="2" />
+            <path d="M8 12v1.5a2.5 2.5 0 0 0 5 0V12" />
+            <path d="M2 12h2" />
+            <path d="M14 2h2" />
+            <path d="M14 8h2" />
+            <path d="M14 14h2" />
+        </svg>
+    </div>
     <div class="ai-fab-notification" id="ai-fab-notification"></div>
-    <div class="ai-assistant-container" id="ai-container"></div>
+    <div class="ai-assistant-container" id="ai-container">
+        <div class="ai-assistant-header">
+            <div class="ai-header-profile">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="var(--accent-color)"
+                    xmlns="http://www.w3.org/2000/svg">
+                    <path d="M12 8V4H8" /><rect x="4" y="12" width="8" height="8" rx="2" /><path d="M8 12v1.5a2.5 2.5 0 0 0 5 0V12" /><path d="M2 12h2" /><path d="M14 2h2" /><path d="M14 8h2" /><path d="M14 14h2" />
+                </svg>
+                <h3 data-translate-key="ai_title">Assistant Virtuel</h3>
+            </div>
+            <button class="ai-close-btn" id="ai-close-btn">&times;</button>
+        </div>
+        <div class="ai-assistant-body" id="ai-chat-box">
+            <div class="ai-message assistant">
+                <p data-translate-key="ai_welcome">Bonjour ! Je suis l'assistant virtuel de Mohamed. Comment puis-je
+                    vous aider à découvrir son profil ? Voici quelques suggestions :</p>
+            </div>
+            <div class="ai-suggestions" id="ai-suggestions">
+                <button class="suggestion-btn" data-translate-key="ai_sugg_1">Résume son expérience</button>
+                <button class="suggestion-btn" data-translate-key="ai_sugg_2">Quelles sont ses compétences en PDM ?</button>
+                <button class="suggestion-btn" data-translate-key="ai_sugg_3">Où a-t-il étudié ?</button>
+            </div>
+        </div>
+        <div class="ai-assistant-footer">
+            <input type="text" id="ai-input" placeholder="Posez votre question ici..." autocomplete="off">
+            <button id="ai-send-btn">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
+                    stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <line x1="22" y1="2" x2="11" y2="13"></line>
+                    <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+                </svg>
+            </button>
+        </div>
+    </div>
 
     <script src="/assets/js/script.js"></script>
     <script type="module" src="/assets/js/blog.js"></script>


### PR DESCRIPTION
## Summary
- align blog list, article pages, and template with the complete AI assistant markup used on the portfolio landing page
- harden `initAIAssistant` by validating DOM nodes, extracting blog-specific context, and forwarding page metadata to the backend
- extend the Gemini API handler to consume the page type and label the injected context segment accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d13fae12f0832f83d52c5d734f4ae6