### PR TITLE
Refine language handling for blog and portfolio

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -9,6 +9,7 @@ const translations = {
         "nav_skills": "Compétences",
         "nav_education": "Formation",
         "nav_contact": "Contact",
+        "nav_blog": "Blog",
         "hero_title": `<span class="highlight glitch" data-text="Ingénieur Mécanique">Ingénieur Mécanique</span> & <br>Consultant <span class="glitch" data-text="PDM/PLM">PDM/PLM</span>`,
         "hero_subtitle": "Expertise en conception, implémentation de solutions PDM et gestion du cycle de vie produit",
         "hero_cta1": "Me contacter",
@@ -106,6 +107,7 @@ const translations = {
         "nav_skills": "Skills",
         "nav_education": "Education",
         "nav_contact": "Contact",
+        "nav_blog": "Blog",
         "hero_title": `<span class="highlight glitch" data-text="Mechanical Engineer">Mechanical Engineer</span> & <br>PDM/PLM <span class="glitch" data-text="Consultant">Consultant</span>`,
         "hero_subtitle": "Expertise in design, PDM solution implementation, and product lifecycle management",
         "hero_cta1": "Contact Me",
@@ -195,6 +197,424 @@ const translations = {
         "ai_sugg_3": "Where did he study?"
     }
 };
+
+const blogTranslations = {
+    fr: {
+        common: {
+            blog_back_to_blog: "← Retour au blog",
+            blog_back_to_portfolio: "Retour au portfolio",
+            blog_badge_editorial: "Article de fond",
+            blog_cta_summary: "Consulter le sommaire",
+            blog_cta_discuss_project: "Discuter de votre projet",
+            blog_summary_title: "Sommaire"
+        },
+        pages: {
+            index: {
+                blog_index_filter_all: "Tout",
+                blog_index_filter_editorial: "Articles de fond",
+                blog_index_section_editorial_title: "Articles de fond",
+                blog_index_section_editorial_subtitle: "Analyses éditoriales, retours d’expérience et bonnes pratiques terrain."
+            }
+        },
+        articles: {
+            "configuration-materielle-solidworks": {
+                blog_config_badge_guide: "Guide matériel",
+                blog_config_hero_eyebrow: "SOLIDWORKS &amp; PDM",
+                blog_config_hero_title: "Configuration matérielle SOLIDWORKS 2025 : le guide terrain pour un bureau d'études réactif",
+                blog_config_hero_subtitle: `Publié le <span data-date-iso="2025-09-21T00:00:00.000Z" data-date-format="long">21 septembre 2025</span> après douze missions de diagnostic CAO : comment dimensionner stations, serveur PDM et réseau pour éliminer les goulots d'étranglement avant la saison des pics de charge.`,
+                blog_config_stat_publication: "Date de publication",
+                blog_config_stat_profiles: "Profils de stations validés",
+                blog_config_stat_gain: "Gain moyen sur les temps d'ouverture",
+                blog_config_summary_label1: "Pourquoi optimiser le matériel maintenant&nbsp;?",
+                blog_config_summary_meta1: "Les signaux terrain et KPI à surveiller",
+                blog_config_summary_label2: "Audit express d'un parc CAO",
+                blog_config_summary_meta2: "Méthode en trois temps, outils et seuils",
+                blog_config_summary_label3: "Trois profils de stations prêts à déployer",
+                blog_config_summary_meta3: "Spécifications, coûts et impact utilisateur",
+                blog_config_summary_label4: "Serveur PDM, stockage et réseau",
+                blog_config_summary_meta4: "Architecture type et points de vigilance",
+                blog_config_summary_label5: "Plan d'action 90 jours",
+                blog_config_summary_meta5: "Feuille de route et indicateurs de succès",
+                blog_config_enjeux_title: "1. Pourquoi optimiser le matériel maintenant&nbsp;?",
+                blog_config_enjeux_p1: "Depuis le début de 2025, la plupart des directions de bureaux d'études que j'accompagne cherchent à absorber une hausse des projets sans sacrifier la réactivité. Or les irritants que remontent les concepteurs SOLIDWORKS proviennent rarement de la modélisation elle-même&nbsp;: temps d'ouverture qui dépassent la minute, calculs Simulation qui bloquent un poste toute une après-midi, synchronisations PDM qui saturent les liens inter-sites. Ces signaux faibles finissent par freiner la mise sur le marché.",
+                blog_config_enjeux_quote: "Une plateforme matérielle alignée sur les usages, c'est un dossier critique qui sort 30&nbsp;% plus vite, une production mieux alimentée en données et une DSI qui tient ses engagements de service sans surcoût.",
+                blog_config_enjeux_quote_author: "Mohamed Omar Baouch",
+                blog_config_enjeux_p2: "Les organisations qui franchissent le cap de SOLIDWORKS 2025 avec sérénité partagent le même socle&nbsp;: un environnement matériel contrôlé et instrumenté. Ce guide synthétise les enseignements tirés d'une douzaine d'audits réalisés ces dix-huit derniers mois et propose un cadre opérationnel pour identifier les goulots d'étranglement, prioriser les investissements et sécuriser l'évolutivité.",
+                blog_config_audit_title: "2. Audit express d'un parc CAO",
+                blog_config_audit_intro: "L'objectif est de dresser une cartographie fiable des performances en moins de quinze jours. La démarche se structure autour de trois axes complémentaires qui se nourrissent l'un l'autre.",
+                blog_config_audit_card1_title: "Mesures terrain",
+                blog_config_audit_card1_item1: "Journalisation des temps d'ouverture sur dix assemblages représentatifs",
+                blog_config_audit_card1_item2: "Suivi CPU/GPU via SOLIDWORKS RX complété par HWinfo",
+                blog_config_audit_card1_item3: "Analyse détaillée des temps de check-in/out PDM",
+                blog_config_audit_card2_title: "Entretien utilisateurs",
+                blog_config_audit_card2_item1: "Cartographie des tâches critiques (assemblage, Simulation, Visualize)",
+                blog_config_audit_card2_item2: "Identification des pics de charge hebdomadaires et saisonniers",
+                blog_config_audit_card2_item3: "Évaluation de la maturité PDM&nbsp;: workflows, réplications, discipline documentaire",
+                blog_config_audit_card3_title: "Inventaire IT",
+                blog_config_audit_card3_item1: "Âge, garantie et version de firmware des stations",
+                blog_config_audit_card3_item2: "Topologie réseau, saturation des VLAN et qualité du câblage",
+                blog_config_audit_card3_item3: "Stratégie de sauvegarde et PRA autour du coffre-fort PDM",
+                blog_config_audit_callout: `<strong>Livrable clé :</strong> une matrice qui croise profils utilisateurs et workloads, assortie d'un indicateur de santé (vert / orange / rouge). Elle sert de boussole pour calibrer les investissements ciblés.`,
+                blog_config_profils_title: "3. Trois profils de stations prêts à déployer",
+                blog_config_profils_intro: "Au lieu de multiplier les stations sur mesure, je préconise trois profils standardisés. Ils couvrent plus de 90&nbsp;% des cas observés, simplifient les achats et réduisent la variabilité lors des maintenances.",
+                blog_config_profils_table_header_profile: "Profil",
+                blog_config_profils_table_header_cpu: "CPU",
+                blog_config_profils_table_header_gpu: "GPU",
+                blog_config_profils_table_header_ram: "RAM",
+                blog_config_profils_table_header_storage: "Stockage",
+                blog_config_profils_table_header_usage: "Usage principal",
+                blog_config_profils_row1_label: "Bureau d'études",
+                blog_config_profils_row1_usage: "Assemblages &lt; 5&nbsp;000 pièces, mise en plan",
+                blog_config_profils_row2_label: "Simulation avancée",
+                blog_config_profils_row2_usage: "Simulation statique / thermique / Flow",
+                blog_config_profils_row3_label: "Revue immersive",
+                blog_config_profils_row3_usage: "VR, Visualize, revues clients",
+                blog_config_profils_figcaption: "Trois profils éprouvés sur le terrain&nbsp;: budget maîtrisé, maintenance prévisible et gains visibles dès les premières semaines.",
+                blog_config_profils_callout: `<strong>Astuce terrain :</strong> préparez des images Windows différenciées (Design, Simulation, VR) avec politiques d'alimentation adaptées. Vous évitez les BIOS sous-optimisés et sécurisez un comportement homogène sur tout le parc.`,
+                blog_config_infra_title: "4. Serveur PDM, stockage et réseau",
+                blog_config_infra_intro: "Une station de travail performante ne suffit pas si le coffre-fort PDM ou le réseau devient le nouveau goulot d'étranglement. Les projets les plus fluides reposent sur une architecture complète&nbsp;: serveur applicatif dimensionné, stockage NVMe répliqué et réseau 10&nbsp;GbE qui priorise les flux CAO.",
+                blog_config_infra_figcaption: "Backbone PDM prêt pour la montée en charge&nbsp;: NVMe en production, sauvegarde 3-2-1 et qualité de service appliquée aux flux critiques.",
+                blog_config_infra_server_title: "Serveur PDM",
+                blog_config_infra_server_item1: "CPU Xeon Silver ou AMD EPYC avec 12&nbsp;coeurs minimum",
+                blog_config_infra_server_item2: "128&nbsp;Go de RAM ECC pour absorber les pics de réplication",
+                blog_config_infra_server_item3: "Volumes NVMe en RAID&nbsp;1 pour le vault et SSD SATA pour les archives",
+                blog_config_infra_network_title: "Réseau &amp; QoS",
+                blog_config_infra_network_item1: "Backbone 10&nbsp;GbE redondé, VLAN dédié aux flux CAO",
+                blog_config_infra_network_item2: "QoS priorisant PDM, Visualize et sauvegardes différées",
+                blog_config_infra_network_item3: "VPN avec compression et cache local pour les sites distants",
+                blog_config_infra_chart_text: "Répartition indicative d'un budget de modernisation (en&nbsp;%). Ajustez-la à l'issue de votre audit&nbsp;: les gains rapides proviennent souvent du stockage et du réseau.",
+                blog_config_infra_callout: `<strong>Point de vigilance :</strong> synchronisez vos maintenances avec les cycles de sauvegarde et institutionnalisez un test mensuel de restauration du coffre-fort. Un PRA documenté évite les arrêts de production lors des mises à jour SOLIDWORKS.`,
+                blog_config_plan_title: "5. Plan d'action 90 jours",
+                blog_config_plan_intro: "Une fois la cible validée, structurez la mise en œuvre en trois sprints de trente jours. Objectif&nbsp;: livrer des améliorations visibles dès le premier mois tout en sécurisant la trajectoire long terme.",
+                blog_config_plan_item1: `<strong>Sprint&nbsp;1&nbsp;:</strong> commandes et quick wins (SSD NVMe, BIOS à jour, tuning Windows). KPI&nbsp;: temps d'ouverture moyen &lt;&nbsp;45&nbsp;secondes.`,
+                blog_config_plan_item2: `<strong>Sprint&nbsp;2&nbsp;:</strong> déploiement des nouvelles stations et mise à niveau réseau. KPI&nbsp;: zéro erreur de check-in PDM, latence moyenne &lt;&nbsp;2&nbsp;ms.`,
+                blog_config_plan_item3: `<strong>Sprint&nbsp;3&nbsp;:</strong> bascule serveur PDM, sauvegarde 3-2-1, formation utilisateurs. KPI&nbsp;: satisfaction utilisateurs &gt;&nbsp;8/10, PRA testé et validé.`,
+                blog_config_plan_outro: "Ce plan permet d'engranger des gains dès le premier mois tout en alignant IT, bureau d'études et direction industrielle sur la même feuille de route.",
+                blog_config_cta_title: "Vous voulez fiabiliser votre environnement SOLIDWORKS&nbsp;?",
+                blog_config_cta_text: "Je vous aide à cadrer l'audit, hiérarchiser les investissements et orchestrer le déploiement sans interrompre la production. Discutons de vos priorités.",
+                blog_config_cta_button: "Planifier un échange"
+            },
+            "resolutions-problematiques-plm": {
+                blog_plm_hero_eyebrow: "Expérience terrain",
+                blog_plm_hero_title: "Au-delà de la théorie : résoudre les 5 problématiques PLM que j'ai vécues en tant qu'Ingénieur Mécanique",
+                blog_plm_hero_subtitle: `Retour d'expérience publié le <span data-date-iso="2025-09-15T00:00:00.000Z" data-date-format="long">15 septembre 2025</span> : comment passer des discours aux actions concrètes pour sécuriser données, nomenclatures et collaboration.`,
+                blog_plm_stat_publication: "Date de publication",
+                blog_plm_stat_issues: "Problématiques traitées",
+                blog_plm_stat_expertise: "Expertise terrain",
+                blog_plm_summary_label1: "Silos de données qui fragmentent le savoir",
+                blog_plm_summary_meta1: "De l'enquête manuelle au coffre-fort PDM",
+                blog_plm_summary_label2: "Erreurs dans les nomenclatures",
+                blog_plm_summary_meta2: "Quand Excel fait dérailler la production",
+                blog_plm_summary_label3: "Versions incontrôlées et confusion",
+                blog_plm_summary_meta3: "Le risque caché des dossiers « finale_v3 »",
+                blog_plm_summary_label4: "Collaboration freinée entre BE et production",
+                blog_plm_summary_meta4: "Du mail perdu au workflow tracé",
+                blog_plm_summary_label5: "Traçabilité et conformité sous tension",
+                blog_plm_summary_meta5: "Répondre à un audit en quelques clics",
+                blog_plm_intro_p1: "Quand j'ai débuté comme ingénieur mécanique, la gestion des données produit me semblait un sujet réservé aux grandes entreprises et aux théoriciens des processus. La réalité du terrain m'a vite montré l'inverse. Chez Evolum puis chez ABMI, j'ai vu comment un simple plan mal versionné pouvait immobiliser une ligne de production ou comment une nomenclature erronée pouvait faire exploser les coûts d'un projet.",
+                blog_plm_intro_quote: "Un PDM/PLM bien implémenté n'est pas un luxe : c'est un filet de sécurité qui libère les équipes de la chasse aux informations pour qu'elles se concentrent sur l'innovation.",
+                blog_plm_intro_author: "Mohamed Omar Baouch",
+                blog_plm_intro_p2: "Au fil des projets, j'ai identifié cinq problématiques récurrentes. Elles ne sont pas théoriques : chacune est issue d'un incident concret, d'un retard de production ou d'un audit stressant. Voici la synthèse des symptômes et des réponses mises en place avec les équipes terrain.",
+                blog_plm_table_header_issue: "Problématique",
+                blog_plm_table_header_impact: "Impact terrain",
+                blog_plm_table_header_solution: "Solution PLM appliquée",
+                blog_plm_table_row1_issue: "Silos de données",
+                blog_plm_table_row1_impact: "Temps perdu à retrouver la bonne version",
+                blog_plm_table_row1_solution: "Coffre-fort PDM centralisé et droits maîtrisés",
+                blog_plm_table_row2_issue: "Nomenclatures instables",
+                blog_plm_table_row2_impact: "Achats erronés, prototypes retardés",
+                blog_plm_table_row2_solution: "Génération automatique des BOM depuis la CAO",
+                blog_plm_table_row3_issue: "Versions incontrôlées",
+                blog_plm_table_row3_impact: "Production lancée sur un plan obsolète",
+                blog_plm_table_row3_solution: "Gestion des révisions et workflow de validation",
+                blog_plm_table_row4_issue: "Collaboration freinée",
+                blog_plm_table_row4_impact: "Feedback perdu entre mail et atelier",
+                blog_plm_table_row4_solution: "Workflows intégrés entre BE et production",
+                blog_plm_table_row5_issue: "Traçabilité fragile",
+                blog_plm_table_row5_impact: "Audits retardés, confiance client fragilisée",
+                blog_plm_table_row5_solution: "Historique complet et généalogie des pièces",
+                blog_plm_silos_title: "1. Silos de données qui fragmentent le savoir",
+                blog_plm_silos_p1: "À mes débuts chez Evolum, chacun travaillait dans son coin. Les fichiers de conception étaient dispersés entre des disques partagés, des clés USB et parfois des ordinateurs personnels. Lorsque je devais reprendre un projet, je passais plus de temps à chercher la bonne version d'un assemblage qu'à concevoir.",
+                blog_plm_silos_p2: "Cette fragmentation du savoir faisait perdre un temps précieux et créait des divergences entre les bureaux d'études et l'atelier. La mise en place d'un coffre-fort PDM centralisé a été une révélation : chaque modèle était stocké une seule fois, les droits d'accès étaient clairs et je pouvais retracer l'historique complet d'une pièce sans lever de téléphone.",
+                blog_plm_silos_callout: `<strong>Clé du succès :</strong> rendre le PDM incontournable en l'intégrant dans les habitudes quotidiennes (check-in/check-out, commentaires, workflows de revue).`,
+                blog_plm_nomenclature_title: "2. Erreurs dans les nomenclatures",
+                blog_plm_nomenclature_p1: "Lors d'une mission chez ABMI, j'ai vécu les conséquences d'une nomenclature gérée sous Excel. Une ligne oubliée a entraîné l'achat de pièces supplémentaires et plusieurs jours de retard sur un prototype. C'est à ce moment que j'ai compris l'importance d'un système PLM capable de générer des nomenclatures cohérentes directement depuis la CAO et de les lier aux achats.",
+                blog_plm_nomenclature_before_title: "Avant",
+                blog_plm_nomenclature_before_item1: "Excel partagé par mail",
+                blog_plm_nomenclature_before_item2: "Versions multiples sans historique",
+                blog_plm_nomenclature_before_item3: "Décisions prises hors système",
+                blog_plm_nomenclature_after_title: "Après",
+                blog_plm_nomenclature_after_item1: "BOM générée automatiquement",
+                blog_plm_nomenclature_after_item2: "Validation croisée avec les achats",
+                blog_plm_nomenclature_after_item3: "Historique des modifications consolidé",
+                blog_plm_nomenclature_p2: "Avec SolidWorks PDM, nous avons automatisé l'extraction des BOM et mis en place des règles de validation qui ont supprimé ce type d'erreurs. L'équipe projet gagnait en sérénité et les réunions ne tournaient plus autour de la question « qui possède la bonne version ? ».",
+                blog_plm_versions_title: "3. Versions incontrôlées et confusion",
+                blog_plm_versions_p1: "Avant d'adopter un PDM, la gestion des révisions se résumait à des suffixes dans les noms de fichiers. Il n'était pas rare de voir des dossiers remplis de \"finale\", \"finale2\" ou \"version_definitive_v3\". Lors de mon passage chez Evolum, cette pratique a provoqué la fabrication d'un lot de pièces basé sur un plan obsolète.",
+                blog_plm_versions_p2: "En implémentant un véritable PLM chez Visiativ, j'ai découvert la puissance du contrôle de versions : chaque modification est tracée, commentée et validée. Les transitions de statuts (en conception, en validation, publié) ont apporté une clarté immédiate et réduit drastiquement les allers-retours improductifs.",
+                blog_plm_collaboration_title: "4. Collaboration freinée entre bureaux d'études et production",
+                blog_plm_collaboration_p1: "La collaboration se limitait souvent à l'échange de fichiers par email. Les retours de l'atelier arrivaient tard et les remarques se perdaient dans les boîtes de réception. En tant que consultant chez Visiativ, j'ai accompagné plusieurs clients dans l'intégration de workflows qui relient directement la conception à la production.",
+                blog_plm_collaboration_p2: "Grâce à un PDM bien configuré, l'atelier peut annoter les modèles, proposer des modifications et suivre leur prise en compte. Cette boucle de feedback en continu a transformé la relation entre les équipes et réduit drastiquement les erreurs de fabrication.",
+                blog_plm_traceability_title: "5. Traçabilité et conformité",
+                blog_plm_traceability_p1: "Dans des secteurs réglementés, prouver la conformité d'un produit est aussi important que le produit lui-même. Avant l'arrivée d'un PLM, la traçabilité reposait sur des dossiers papier et la mémoire des ingénieurs. J'ai vu un audit repoussé parce qu'il était impossible de démontrer la généalogie complète d'un composant.",
+                blog_plm_traceability_p2: "Avec un PLM, chaque décision, chaque validation et chaque version est enregistrée. Lors d'un projet piloté par Visiativ, nous avons pu répondre à un audit en quelques clics, fournissant l'historique complet des modifications d'une pièce critique. La confiance du client s'en est trouvée renforcée.",
+                blog_plm_outro_p1: "Ces cinq problématiques ne sont pas de simples cas d'école. Elles ont freiné des projets auxquels j'ai participé et m'ont parfois laissé un goût d'inachevé. Aujourd'hui, en tant que consultant PDM/PLM chez Visiativ, je mets cette expérience au service des entreprises qui veulent éviter ces pièges.",
+                blog_plm_cta_title: "Envie de résoudre vos problématiques PLM&nbsp;?",
+                blog_plm_cta_text: "Construisons ensemble une feuille de route pragmatique, ancrée dans votre réalité terrain. Une simple discussion peut révéler les priorités à adresser en premier.",
+                blog_plm_cta_button: "Planifier un échange"
+            }
+        }
+    },
+    en: {
+        common: {
+            blog_back_to_blog: "← Back to the blog",
+            blog_back_to_portfolio: "Back to the portfolio",
+            blog_badge_editorial: "Feature article",
+            blog_cta_summary: "View the outline",
+            blog_cta_discuss_project: "Discuss your project",
+            blog_summary_title: "Outline"
+        },
+        pages: {
+            index: {
+                blog_index_filter_all: "All",
+                blog_index_filter_editorial: "Feature articles",
+                blog_index_section_editorial_title: "Feature articles",
+                blog_index_section_editorial_subtitle: "Editorial analyses, field feedback, and practical best practices."
+            }
+        },
+        articles: {
+            "configuration-materielle-solidworks": {
+                blog_config_badge_guide: "Hardware guide",
+                blog_config_hero_eyebrow: "SOLIDWORKS &amp; PDM",
+                blog_config_hero_title: "SOLIDWORKS 2025 hardware configuration: the field guide for an agile design office",
+                blog_config_hero_subtitle: `Published on <span data-date-iso="2025-09-21T00:00:00.000Z" data-date-format="long"></span> after twelve CAD diagnostics: how to size workstations, the PDM server, and the network to eliminate bottlenecks before peak season.`,
+                blog_config_stat_publication: "Publication date",
+                blog_config_stat_profiles: "Validated workstation profiles",
+                blog_config_stat_gain: "Average gain on opening times",
+                blog_config_summary_label1: "Why optimize hardware now?",
+                blog_config_summary_meta1: "Signals from the field and KPIs to monitor",
+                blog_config_summary_label2: "Rapid audit of a CAD environment",
+                blog_config_summary_meta2: "Three-step method, tools, and thresholds",
+                blog_config_summary_label3: "Three ready-to-deploy workstation profiles",
+                blog_config_summary_meta3: "Specifications, costs, and user impact",
+                blog_config_summary_label4: "PDM server, storage, and network",
+                blog_config_summary_meta4: "Reference architecture and watchpoints",
+                blog_config_summary_label5: "90-day action plan",
+                blog_config_summary_meta5: "Roadmap and success indicators",
+                blog_config_enjeux_title: "1. Why optimize hardware now?",
+                blog_config_enjeux_p1: "Since the start of 2025, most design office leaders I support are trying to absorb more projects without sacrificing responsiveness. Yet the pain points raised by SOLIDWORKS designers rarely stem from modeling itself: opening times that exceed a minute, Simulation runs that block a workstation for an entire afternoon, PDM synchronizations that saturate inter-site links. These weak signals eventually slow down time-to-market.",
+                blog_config_enjeux_quote: "A hardware platform aligned with actual usage means a critical file is released 30% faster, production stays well supplied with data, and IT delivers service levels without overspending.",
+                blog_config_enjeux_quote_author: "Mohamed Omar Baouch",
+                blog_config_enjeux_p2: "Organizations that approach SOLIDWORKS 2025 with confidence share the same foundation: a controlled, instrumented hardware environment. This guide summarizes a dozen audits carried out over the past eighteen months and offers an operational framework to identify bottlenecks, prioritize investments, and secure scalability.",
+                blog_config_audit_title: "2. Rapid audit of a CAD environment",
+                blog_config_audit_intro: "The goal is to establish a reliable performance map in under fifteen days. The approach is structured around three complementary axes that feed each other.",
+                blog_config_audit_card1_title: "Field measurements",
+                blog_config_audit_card1_item1: "Log opening times on ten representative assemblies",
+                blog_config_audit_card1_item2: "Track CPU/GPU usage via SOLIDWORKS RX supplemented with HWinfo",
+                blog_config_audit_card1_item3: "Detailed analysis of PDM check-in/check-out times",
+                blog_config_audit_card2_title: "User interviews",
+                blog_config_audit_card2_item1: "Map critical tasks (assemblies, Simulation, Visualize)",
+                blog_config_audit_card2_item2: "Identify weekly and seasonal peak loads",
+                blog_config_audit_card2_item3: "Assess PDM maturity: workflows, replication, document discipline",
+                blog_config_audit_card3_title: "IT inventory",
+                blog_config_audit_card3_item1: "Station age, warranty, and firmware version",
+                blog_config_audit_card3_item2: "Network topology, VLAN saturation, and cabling quality",
+                blog_config_audit_card3_item3: "Backup strategy and disaster recovery around the PDM vault",
+                blog_config_audit_callout: `<strong>Key deliverable:</strong> a matrix crossing user profiles and workloads, paired with a health indicator (green / orange / red). It is the compass for calibrating targeted investments.`,
+                blog_config_profils_title: "3. Three ready-to-deploy workstation profiles",
+                blog_config_profils_intro: "Instead of multiplying custom stations, I recommend three standardized profiles. They cover over 90% of observed cases, simplify purchasing, and reduce variability during maintenance.",
+                blog_config_profils_table_header_profile: "Profile",
+                blog_config_profils_table_header_cpu: "CPU",
+                blog_config_profils_table_header_gpu: "GPU",
+                blog_config_profils_table_header_ram: "RAM",
+                blog_config_profils_table_header_storage: "Storage",
+                blog_config_profils_table_header_usage: "Primary use",
+                blog_config_profils_row1_label: "Design office",
+                blog_config_profils_row1_usage: "Assemblies &lt; 5&nbsp;000 parts, drafting",
+                blog_config_profils_row2_label: "Advanced simulation",
+                blog_config_profils_row2_usage: "Structural, thermal, and Flow Simulation",
+                blog_config_profils_row3_label: "Immersive review",
+                blog_config_profils_row3_usage: "VR, Visualize, client reviews",
+                blog_config_profils_figcaption: "Three field-proven profiles: controlled budget, predictable maintenance, and visible gains from the first weeks.",
+                blog_config_profils_callout: `<strong>Field tip:</strong> prepare separate Windows images (Design, Simulation, VR) with tailored power policies. You avoid under-tuned BIOS settings and ensure consistent behavior across the fleet.`,
+                blog_config_infra_title: "4. PDM server, storage, and network",
+                blog_config_infra_intro: "A powerful workstation is not enough if the PDM vault or the network becomes the new bottleneck. The smoothest projects rely on a complete architecture: properly sized application server, replicated NVMe storage, and 10&nbsp;GbE networking that prioritizes CAD traffic.",
+                blog_config_infra_figcaption: "PDM backbone ready to scale: NVMe in production, 3-2-1 backup, and quality of service applied to critical flows.",
+                blog_config_infra_server_title: "PDM server",
+                blog_config_infra_server_item1: "Xeon Silver or AMD EPYC CPU with at least 12 cores",
+                blog_config_infra_server_item2: "128&nbsp;GB ECC RAM to absorb replication peaks",
+                blog_config_infra_server_item3: "NVMe RAID&nbsp;1 volumes for the vault and SATA SSDs for archives",
+                blog_config_infra_network_title: "Network &amp; QoS",
+                blog_config_infra_network_item1: "Redundant 10&nbsp;GbE backbone with a VLAN dedicated to CAD traffic",
+                blog_config_infra_network_item2: "QoS prioritizing PDM, Visualize, and deferred backups",
+                blog_config_infra_network_item3: "VPN with compression and local caching for remote sites",
+                blog_config_infra_chart_text: "Indicative breakdown of a modernization budget (%). Adjust it after your audit: quick wins often come from storage and the network.",
+                blog_config_infra_callout: `<strong>Watchpoint:</strong> align maintenance windows with backup cycles and institutionalize a monthly vault restoration test. A documented DR plan prevents production stops during SOLIDWORKS upgrades.`,
+                blog_config_plan_title: "5. 90-day action plan",
+                blog_config_plan_intro: "Once the target is validated, structure execution into three thirty-day sprints. Objective: deliver visible improvements from month one while securing the long-term trajectory.",
+                blog_config_plan_item1: `<strong>Sprint&nbsp;1:</strong> orders and quick wins (NVMe SSDs, up-to-date BIOS, Windows tuning). KPI: average opening time &lt;&nbsp;45&nbsp;seconds.`,
+                blog_config_plan_item2: `<strong>Sprint&nbsp;2:</strong> deploy new stations and upgrade the network. KPI: zero PDM check-in errors, average latency &lt;&nbsp;2&nbsp;ms.`,
+                blog_config_plan_item3: `<strong>Sprint&nbsp;3:</strong> switch the PDM server, implement 3-2-1 backups, train users. KPI: user satisfaction &gt;&nbsp;8/10, DR plan tested and approved.`,
+                blog_config_plan_outro: "This plan generates gains from the first month while aligning IT, the design office, and operations on the same roadmap.",
+                blog_config_cta_title: "Want to stabilize your SOLIDWORKS environment?",
+                blog_config_cta_text: "I help you frame the audit, prioritize investments, and orchestrate deployment without interrupting production. Let's discuss your priorities.",
+                blog_config_cta_button: "Schedule a call"
+            },
+            "resolutions-problematiques-plm": {
+                blog_plm_hero_eyebrow: "Field experience",
+                blog_plm_hero_title: "Beyond theory: solving the 5 PLM challenges I experienced as a Mechanical Engineer",
+                blog_plm_hero_subtitle: `Field feedback published on <span data-date-iso="2025-09-15T00:00:00.000Z" data-date-format="long"></span>: how to move from talk to concrete actions to secure data, BOMs, and collaboration.`,
+                blog_plm_stat_publication: "Publication date",
+                blog_plm_stat_issues: "Challenges addressed",
+                blog_plm_stat_expertise: "Field expertise",
+                blog_plm_summary_label1: "Data silos fragmenting knowledge",
+                blog_plm_summary_meta1: "From manual searches to a secured PDM vault",
+                blog_plm_summary_label2: "Errors in bills of materials",
+                blog_plm_summary_meta2: "When Excel derails production",
+                blog_plm_summary_label3: "Uncontrolled versions and confusion",
+                blog_plm_summary_meta3: "The hidden risk of “final_v3” folders",
+                blog_plm_summary_label4: "Collaboration slowed between design and production",
+                blog_plm_summary_meta4: "From lost emails to tracked workflows",
+                blog_plm_summary_label5: "Traceability and compliance under pressure",
+                blog_plm_summary_meta5: "Answering an audit in a few clicks",
+                blog_plm_intro_p1: "When I started as a mechanical engineer, product data management seemed reserved for large companies and process theorists. Reality quickly proved otherwise. At Evolum and later ABMI, I saw how a single mis-versioned drawing could stop a production line or how an inconsistent BOM could explode a project’s costs.",
+                blog_plm_intro_quote: "A well-implemented PDM/PLM is not a luxury: it is a safety net that frees teams from chasing information so they can focus on innovation.",
+                blog_plm_intro_author: "Mohamed Omar Baouch",
+                blog_plm_intro_p2: "Across projects I identified five recurring challenges. They are not theoretical: each stems from a concrete incident, a production delay, or a stressful audit. Here is a synthesis of the symptoms and the responses built with field teams.",
+                blog_plm_table_header_issue: "Challenge",
+                blog_plm_table_header_impact: "Impact on the field",
+                blog_plm_table_header_solution: "Applied PLM solution",
+                blog_plm_table_row1_issue: "Data silos",
+                blog_plm_table_row1_impact: "Time wasted finding the right version",
+                blog_plm_table_row1_solution: "Centralized PDM vault with controlled access",
+                blog_plm_table_row2_issue: "Unstable BOMs",
+                blog_plm_table_row2_impact: "Wrong purchases, delayed prototypes",
+                blog_plm_table_row2_solution: "Automatic BOM generation from CAD",
+                blog_plm_table_row3_issue: "Uncontrolled versions",
+                blog_plm_table_row3_impact: "Production launched on an outdated drawing",
+                blog_plm_table_row3_solution: "Revision management and approval workflow",
+                blog_plm_table_row4_issue: "Slowed collaboration",
+                blog_plm_table_row4_impact: "Feedback lost between email and the shop floor",
+                blog_plm_table_row4_solution: "Integrated workflows between design and production",
+                blog_plm_table_row5_issue: "Fragile traceability",
+                blog_plm_table_row5_impact: "Delayed audits, weakened customer trust",
+                blog_plm_table_row5_solution: "Complete history and part genealogy",
+                blog_plm_silos_title: "1. Data silos fragmenting knowledge",
+                blog_plm_silos_p1: "At my start with Evolum, everyone worked in isolation. Design files were scattered across shared drives, USB sticks, and sometimes personal computers. When I had to take over a project, I spent more time searching for the right assembly version than actually designing.",
+                blog_plm_silos_p2: "This fragmented knowledge wasted precious time and created discrepancies between design offices and the workshop. Deploying a centralized PDM vault was a revelation: each model was stored once, access rights were clear, and I could trace a part’s entire history without picking up the phone.",
+                blog_plm_silos_callout: `<strong>Success key:</strong> make the PDM indispensable by embedding it into daily habits (check-in/check-out, comments, review workflows).`,
+                blog_plm_nomenclature_title: "2. Errors in bills of materials",
+                blog_plm_nomenclature_p1: "During a mission at ABMI I experienced the consequences of managing a BOM in Excel. One missing line led to extra parts being ordered and several days of delay on a prototype. That’s when I realized the importance of a PLM capable of generating consistent BOMs directly from CAD and linking them to purchasing.",
+                blog_plm_nomenclature_before_title: "Before",
+                blog_plm_nomenclature_before_item1: "Excel shared by email",
+                blog_plm_nomenclature_before_item2: "Multiple versions with no history",
+                blog_plm_nomenclature_before_item3: "Decisions taken outside the system",
+                blog_plm_nomenclature_after_title: "After",
+                blog_plm_nomenclature_after_item1: "BOM generated automatically",
+                blog_plm_nomenclature_after_item2: "Cross-check with purchasing",
+                blog_plm_nomenclature_after_item3: "Consolidated change history",
+                blog_plm_nomenclature_p2: "With SOLIDWORKS PDM we automated BOM extraction and implemented validation rules that eliminated this kind of error. The project team gained peace of mind and meetings no longer revolved around “who has the right version?”",
+                blog_plm_versions_title: "3. Uncontrolled versions and confusion",
+                blog_plm_versions_p1: "Before adopting a PDM, revision management boiled down to suffixes in filenames. Folders full of “final”, “final2”, or “version_definitive_v3” were common. During my time at Evolum this practice triggered the production of a batch of parts from an outdated drawing.",
+                blog_plm_versions_p2: "By implementing a true PLM at Visiativ, I discovered the power of version control: every change is tracked, commented, and approved. Status transitions (in design, under review, released) brought immediate clarity and drastically reduced unproductive back-and-forth.",
+                blog_plm_collaboration_title: "4. Collaboration slowed between design offices and production",
+                blog_plm_collaboration_p1: "Collaboration often boiled down to exchanging files by email. Feedback from the shop floor arrived late and comments were lost in inboxes. As a consultant at Visiativ I helped several clients integrate workflows that connect design directly to production.",
+                blog_plm_collaboration_p2: "With a well-configured PDM, the workshop can annotate models, propose changes, and track their adoption. This continuous feedback loop transformed relationships between teams and drastically reduced manufacturing errors.",
+                blog_plm_traceability_title: "5. Traceability and compliance",
+                blog_plm_traceability_p1: "In regulated industries, proving product compliance is as critical as the product itself. Before PLM, traceability relied on paper binders and engineers’ memory. I saw an audit postponed because it was impossible to demonstrate the full genealogy of a component.",
+                blog_plm_traceability_p2: "With a PLM, every decision, approval, and version is recorded. On a project led by Visiativ we answered an audit in just a few clicks, providing the complete change history of a critical part. Customer trust was strengthened.",
+                blog_plm_outro_p1: "These five challenges are not textbook examples. They slowed projects I worked on and sometimes left me frustrated. Today, as a PDM/PLM consultant at Visiativ, I leverage that experience to help companies avoid these pitfalls.",
+                blog_plm_cta_title: "Want to tackle your PLM challenges?",
+                blog_plm_cta_text: "Let's build a pragmatic roadmap anchored in your field reality. A short discussion can surface the priorities to address first.",
+                blog_plm_cta_button: "Schedule a call"
+            }
+        }
+    }
+};
+
+const SUPPORTED_LANGUAGES = ['fr', 'en'];
+
+function isBlogPage() {
+    return document.body?.classList.contains('blog-page');
+}
+
+function getBlogPageKey() {
+    return document.body?.dataset.blogPage || null;
+}
+
+function getBlogPostSlug() {
+    return document.body?.dataset.blogPost || null;
+}
+
+function buildBlogLanguageData(lang) {
+    const config = blogTranslations[lang];
+    if (!config) {
+        return {};
+    }
+    const result = { ...(config.common || {}) };
+    const pageKey = getBlogPageKey();
+    if (pageKey && config.pages?.[pageKey]) {
+        Object.assign(result, config.pages[pageKey]);
+    }
+    const slug = getBlogPostSlug();
+    if (slug && config.articles?.[slug]) {
+        Object.assign(result, config.articles[slug]);
+    }
+    return result;
+}
+
+function formatBlogDates(lang) {
+    const targets = document.querySelectorAll('[data-date-iso]');
+    if (!targets.length) {
+        return;
+    }
+    const locale = lang === 'fr' ? 'fr-FR' : 'en-GB';
+    const longFormatter = new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'long', year: 'numeric' });
+    const shortFormatter = new Intl.DateTimeFormat(locale, { day: '2-digit', month: '2-digit', year: 'numeric' });
+    targets.forEach((element) => {
+        const iso = element.getAttribute('data-date-iso');
+        if (!iso) {
+            return;
+        }
+        const date = new Date(iso);
+        if (Number.isNaN(date.getTime())) {
+            return;
+        }
+        const format = element.getAttribute('data-date-format') || 'long';
+        const formatter = format === 'short' ? shortFormatter : longFormatter;
+        element.textContent = formatter.format(date);
+    });
+}
+
+if (typeof window !== 'undefined') {
+    window.formatBlogDates = formatBlogDates;
+}
+
+function applyPortfolioLanguage(langData, lang) {
+    if (!langData) {
+        return;
+    }
+    const downloadCvLink = document.querySelector('[data-cv-link]');
+    if (downloadCvLink && langData['cv_file']) {
+        downloadCvLink.setAttribute('href', langData['cv_file']);
+    }
+    if (langData['meta_title']) {
+        document.title = langData['meta_title'];
+    }
+    const metaDescription = document.querySelector('meta[name="description"]');
+    if (metaDescription && langData['meta_description']) {
+        metaDescription.setAttribute('content', langData['meta_description']);
+    }
+    const glitchElements = document.querySelectorAll('.glitch');
+    if (glitchElements.length >= 2) {
+        if (lang === 'en') {
+            glitchElements[0].dataset.text = 'Mechanical Engineer';
+            glitchElements[1].dataset.text = 'Consultant';
+        } else {
+            glitchElements[0].dataset.text = 'Ingénieur Mécanique';
+            glitchElements[1].dataset.text = 'PDM/PLM';
+        }
+    }
+}
 const frenchCountries = [
     'BJ', 'BF', 'CG', 'CD', 'CI', 'GA', 'GN', 'ML', 'NE', 'SN', 'TG', 'TD', // Afrique Ouest/Centrale
     'FR', 'MC', 'LU', 'BE', 'CH', // Europe
@@ -227,44 +647,48 @@ function getCookie(name) {
     return null;
 }
 function setLanguage(lang) {
-    if (!['fr', 'en'].includes(lang)) {
+    if (!SUPPORTED_LANGUAGES.includes(lang)) {
         console.warn(`Language '${lang}' not supported. Defaulting to 'fr'.`);
         lang = 'fr';
     }
-    const langData = translations[lang];
-    document.querySelectorAll('[data-translate-key]').forEach(el => {
-        const key = el.dataset.translateKey;
-        if (langData[key]) {
-            el.innerHTML = langData[key];
+    const htmlElement = document.documentElement;
+    if (htmlElement) {
+        htmlElement.lang = lang;
+    }
+    const portfolioLangData = translations[lang] || {};
+    const blogPageActive = isBlogPage();
+    const blogLangData = blogPageActive ? buildBlogLanguageData(lang) : {};
+    document.querySelectorAll('[data-translate-key]').forEach((element) => {
+        const key = element.dataset.translateKey;
+        const value = (blogPageActive ? blogLangData[key] : undefined) ?? portfolioLangData[key];
+        if (value !== undefined) {
+            element.innerHTML = value;
         }
     });
-    const downloadCvLink = document.querySelector('a[href$=".pdf"]');
-    if (downloadCvLink && langData['cv_file']) {
-        downloadCvLink.setAttribute('href', langData['cv_file']);
+    const langFrBtn = document.getElementById('lang-fr');
+    if (langFrBtn) {
+        langFrBtn.classList.toggle('active', lang === 'fr');
     }
-    document.querySelector('html').lang = lang;
-    document.title = langData['meta_title'];
-    document.querySelector('meta[name="description"]').setAttribute('content', langData['meta_description']);
-    document.getElementById('lang-fr').classList.toggle('active', lang === 'fr');
-    document.getElementById('lang-en').classList.toggle('active', lang === 'en');
-    const glitchElements = document.querySelectorAll('.glitch');
-    if (lang === 'en') {
-        glitchElements[0].dataset.text = "Mechanical Engineer";
-        glitchElements[1].dataset.text = "Consultant";
+    const langEnBtn = document.getElementById('lang-en');
+    if (langEnBtn) {
+        langEnBtn.classList.toggle('active', lang === 'en');
+    }
+    if (blogPageActive) {
+        document.dispatchEvent(new CustomEvent('blog:languagechange', { detail: { lang } }));
+        formatBlogDates(lang);
     } else {
-        glitchElements[0].dataset.text = "Ingénieur Mécanique";
-        glitchElements[1].dataset.text = "PDM/PLM";
+        applyPortfolioLanguage(portfolioLangData, lang);
     }
     setCookie('preferred_language', lang, 365);
 }
 async function initializeLanguage() {
     const cookieLang = getCookie('preferred_language');
-    if (cookieLang) {
+    if (cookieLang && SUPPORTED_LANGUAGES.includes(cookieLang)) {
         setLanguage(cookieLang);
         return;
     }
     const browserLang = navigator.language.split('-')[0];
-    if (browserLang === 'fr' || browserLang === 'en') {
+    if (SUPPORTED_LANGUAGES.includes(browserLang)) {
         setLanguage(browserLang);
         return;
     }
@@ -287,8 +711,14 @@ async function initializeLanguage() {
         setLanguage('fr');
     }
 }
-document.getElementById('lang-fr').addEventListener('click', () => setLanguage('fr'));
-document.getElementById('lang-en').addEventListener('click', () => setLanguage('en'));
+const langFrButton = document.getElementById('lang-fr');
+if (langFrButton) {
+    langFrButton.addEventListener('click', () => setLanguage('fr'));
+}
+const langEnButton = document.getElementById('lang-en');
+if (langEnButton) {
+    langEnButton.addEventListener('click', () => setLanguage('en'));
+}
 //--------- LANGUAGE SWITCHER SCRIPT END ---------//
 
 function createHeroGrid() {

--- a/blog/configuration-materielle-solidworks/index.html
+++ b/blog/configuration-materielle-solidworks/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="/assets/css/style.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
 </head>
-<body class="blog-page">
+<body class="blog-page" data-blog-post="configuration-materielle-solidworks">
     <canvas id="transition-canvas"></canvas>
     <div class="perspective-wrapper">
         <div id="perspective-content" class="perspective-content"></div>
@@ -33,12 +33,12 @@
             <a href="/" class="logo">M.BAOUCH</a>
             <div class="nav-right">
                 <ul class="menu" id="menu">
-                    <li><a href="/#about" class="nav-link">À propos</a></li>
-                    <li><a href="/#experience" class="nav-link">Expérience</a></li>
-                    <li><a href="/#skills" class="nav-link">Compétences</a></li>
-                    <li><a href="/#education" class="nav-link">Formation</a></li>
-                    <li><a href="/#contact" class="nav-link">Contact</a></li>
-                    <li><a href="/blog/" class="nav-link">Blog</a></li>
+                    <li><a href="/#about" class="nav-link" data-translate-key="nav_about">À propos</a></li>
+                    <li><a href="/#experience" class="nav-link" data-translate-key="nav_experience">Expérience</a></li>
+                    <li><a href="/#skills" class="nav-link" data-translate-key="nav_skills">Compétences</a></li>
+                    <li><a href="/#education" class="nav-link" data-translate-key="nav_education">Formation</a></li>
+                    <li><a href="/#contact" class="nav-link" data-translate-key="nav_contact">Contact</a></li>
+                    <li><a href="/blog/" class="nav-link" data-translate-key="nav_blog">Blog</a></li>
                 </ul>
                 <div class="language-switcher">
                     <button id="lang-fr" class="lang-btn active">FR</button>
@@ -57,171 +57,171 @@
         <div class="blog-shell" id="blogShell" data-shell>
             <article class="blog-article" data-article-root>
                 <nav class="article-breadcrumbs" aria-label="Navigation secondaire">
-                    <a class="back-link" href="/blog/">← Retour au blog</a>
-                    <a class="back-link back-link--ghost" href="/">Retour au portfolio</a>
+                    <a class="back-link" href="/blog/" data-translate-key="blog_back_to_blog">← Retour au blog</a>
+                    <a class="back-link back-link--ghost" href="/" data-translate-key="blog_back_to_portfolio">Retour au portfolio</a>
                 </nav>
 
                 <header class="blog-hero post-hero" data-component="hero">
                     <div class="hero-intro">
                         <div class="hero-badges">
-                            <span class="badge badge-editorial">Article de fond</span>
-                            <span class="badge">Guide matériel</span>
+                            <span class="badge badge-editorial" data-translate-key="blog_badge_editorial">Article de fond</span>
+                            <span class="badge" data-translate-key="blog_config_badge_guide">Guide matériel</span>
                         </div>
-                        <span class="hero-eyebrow">SOLIDWORKS &amp; PDM</span>
-                        <h1 class="hero-title">Configuration matérielle SOLIDWORKS 2025 : le guide terrain pour un bureau d'études réactif</h1>
-                        <p class="hero-subtitle">Publié le 21 septembre 2025 après douze missions de diagnostic CAO : comment dimensionner stations, serveur PDM et réseau pour éliminer les goulots d'étranglement avant la saison des pics de charge.</p>
+                        <span class="hero-eyebrow" data-translate-key="blog_config_hero_eyebrow">SOLIDWORKS &amp; PDM</span>
+                        <h1 class="hero-title" data-translate-key="blog_config_hero_title">Configuration matérielle SOLIDWORKS 2025 : le guide terrain pour un bureau d'études réactif</h1>
+                        <p class="hero-subtitle" data-translate-key="blog_config_hero_subtitle">Publié le <span data-date-iso="2025-09-21T00:00:00.000Z" data-date-format="long">21 septembre 2025</span> après douze missions de diagnostic CAO : comment dimensionner stations, serveur PDM et réseau pour éliminer les goulots d'étranglement avant la saison des pics de charge.</p>
                         <div class="hero-actions">
-                            <a class="hero-btn" href="#sommaire">Consulter le sommaire</a>
-                            <a class="hero-btn hero-btn--ghost" href="/#contact">Discuter de votre projet</a>
+                            <a class="hero-btn" href="#sommaire" data-translate-key="blog_cta_summary">Consulter le sommaire</a>
+                            <a class="hero-btn hero-btn--ghost" href="/#contact" data-translate-key="blog_cta_discuss_project">Discuter de votre projet</a>
                         </div>
                     </div>
                     <div class="hero-stats">
                         <div class="hero-stat">
-                            <span class="hero-stat-value">21/09/2025</span>
-                            <span class="hero-stat-label">Date de publication</span>
+                            <span class="hero-stat-value" data-date-iso="2025-09-21T00:00:00.000Z" data-date-format="short">21/09/2025</span>
+                            <span class="hero-stat-label" data-translate-key="blog_config_stat_publication">Date de publication</span>
                         </div>
                         <div class="hero-stat">
                             <span class="hero-stat-value">3</span>
-                            <span class="hero-stat-label">Profils de stations validés</span>
+                            <span class="hero-stat-label" data-translate-key="blog_config_stat_profiles">Profils de stations validés</span>
                         </div>
                         <div class="hero-stat">
                             <span class="hero-stat-value">12%</span>
-                            <span class="hero-stat-label">Gain moyen sur les temps d'ouverture</span>
+                            <span class="hero-stat-label" data-translate-key="blog_config_stat_gain">Gain moyen sur les temps d'ouverture</span>
                         </div>
                     </div>
                 </header>
 
                 <nav class="blog-section article-summary" id="sommaire" aria-label="Sommaire de l'article">
-                    <h2 class="summary-title">Sommaire</h2>
+                    <h2 class="summary-title" data-translate-key="blog_summary_title">Sommaire</h2>
                     <ol class="summary-list">
                         <li>
                             <a href="#enjeux-performance">
                                 <span class="summary-index">01</span>
-                                <span class="summary-label">Pourquoi optimiser le matériel maintenant&nbsp;?</span>
-                                <span class="summary-meta">Les signaux terrain et KPI à surveiller</span>
+                                <span class="summary-label" data-translate-key="blog_config_summary_label1">Pourquoi optimiser le matériel maintenant&nbsp;?</span>
+                                <span class="summary-meta" data-translate-key="blog_config_summary_meta1">Les signaux terrain et KPI à surveiller</span>
                             </a>
                         </li>
                         <li>
                             <a href="#audit-initial">
                                 <span class="summary-index">02</span>
-                                <span class="summary-label">Audit express d'un parc CAO</span>
-                                <span class="summary-meta">Méthode en trois temps, outils et seuils</span>
+                                <span class="summary-label" data-translate-key="blog_config_summary_label2">Audit express d'un parc CAO</span>
+                                <span class="summary-meta" data-translate-key="blog_config_summary_meta2">Méthode en trois temps, outils et seuils</span>
                             </a>
                         </li>
                         <li>
                             <a href="#profils-workstations">
                                 <span class="summary-index">03</span>
-                                <span class="summary-label">Trois profils de stations prêts à déployer</span>
-                                <span class="summary-meta">Spécifications, coûts et impact utilisateur</span>
+                                <span class="summary-label" data-translate-key="blog_config_summary_label3">Trois profils de stations prêts à déployer</span>
+                                <span class="summary-meta" data-translate-key="blog_config_summary_meta3">Spécifications, coûts et impact utilisateur</span>
                             </a>
                         </li>
                         <li>
                             <a href="#infrastructure">
                                 <span class="summary-index">04</span>
-                                <span class="summary-label">Serveur PDM, stockage et réseau</span>
-                                <span class="summary-meta">Architecture type et points de vigilance</span>
+                                <span class="summary-label" data-translate-key="blog_config_summary_label4">Serveur PDM, stockage et réseau</span>
+                                <span class="summary-meta" data-translate-key="blog_config_summary_meta4">Architecture type et points de vigilance</span>
                             </a>
                         </li>
                         <li>
                             <a href="#plan-daction">
                                 <span class="summary-index">05</span>
-                                <span class="summary-label">Plan d'action 90 jours</span>
-                                <span class="summary-meta">Feuille de route et indicateurs de succès</span>
+                                <span class="summary-label" data-translate-key="blog_config_summary_label5">Plan d'action 90 jours</span>
+                                <span class="summary-meta" data-translate-key="blog_config_summary_meta5">Feuille de route et indicateurs de succès</span>
                             </a>
                         </li>
                     </ol>
                 </nav>
 
                 <section class="blog-section article-section" id="enjeux-performance">
-                    <h2>1. Pourquoi optimiser le matériel maintenant&nbsp;?</h2>
-                    <p>Depuis le début de 2025, la plupart des directions de bureaux d'études que j'accompagne cherchent à absorber une hausse des projets sans sacrifier la réactivité. Or les irritants que remontent les concepteurs SOLIDWORKS proviennent rarement de la modélisation elle-même&nbsp;: temps d'ouverture qui dépassent la minute, calculs Simulation qui bloquent un poste toute une après-midi, synchronisations PDM qui saturent les liens inter-sites. Ces signaux faibles finissent par freiner la mise sur le marché.</p>
+                    <h2 data-translate-key="blog_config_enjeux_title">1. Pourquoi optimiser le matériel maintenant&nbsp;?</h2>
+                    <p data-translate-key="blog_config_enjeux_p1">Depuis le début de 2025, la plupart des directions de bureaux d'études que j'accompagne cherchent à absorber une hausse des projets sans sacrifier la réactivité. Or les irritants que remontent les concepteurs SOLIDWORKS proviennent rarement de la modélisation elle-même&nbsp;: temps d'ouverture qui dépassent la minute, calculs Simulation qui bloquent un poste toute une après-midi, synchronisations PDM qui saturent les liens inter-sites. Ces signaux faibles finissent par freiner la mise sur le marché.</p>
                     <div class="callout">
                         <div class="quote-block">
-                            <blockquote>Une plateforme matérielle alignée sur les usages, c'est un dossier critique qui sort 30&nbsp;% plus vite, une production mieux alimentée en données et une DSI qui tient ses engagements de service sans surcoût.</blockquote>
-                            <cite>Mohamed Omar Baouch</cite>
+                            <blockquote data-translate-key="blog_config_enjeux_quote">Une plateforme matérielle alignée sur les usages, c'est un dossier critique qui sort 30&nbsp;% plus vite, une production mieux alimentée en données et une DSI qui tient ses engagements de service sans surcoût.</blockquote>
+                            <cite data-translate-key="blog_config_enjeux_quote_author">Mohamed Omar Baouch</cite>
                         </div>
                     </div>
-                    <p>Les organisations qui franchissent le cap de SOLIDWORKS 2025 avec sérénité partagent le même socle&nbsp;: un environnement matériel contrôlé et instrumenté. Ce guide synthétise les enseignements tirés d'une douzaine d'audits réalisés ces dix-huit derniers mois et propose un cadre opérationnel pour identifier les goulots d'étranglement, prioriser les investissements et sécuriser l'évolutivité.</p>
+                    <p data-translate-key="blog_config_enjeux_p2">Les organisations qui franchissent le cap de SOLIDWORKS 2025 avec sérénité partagent le même socle&nbsp;: un environnement matériel contrôlé et instrumenté. Ce guide synthétise les enseignements tirés d'une douzaine d'audits réalisés ces dix-huit derniers mois et propose un cadre opérationnel pour identifier les goulots d'étranglement, prioriser les investissements et sécuriser l'évolutivité.</p>
                 </section>
 
                 <section class="blog-section article-section" id="audit-initial">
-                    <h2>2. Audit express d'un parc CAO</h2>
-                    <p>L'objectif est de dresser une cartographie fiable des performances en moins de quinze jours. La démarche se structure autour de trois axes complémentaires qui se nourrissent l'un l'autre.</p>
+                    <h2 data-translate-key="blog_config_audit_title">2. Audit express d'un parc CAO</h2>
+                    <p data-translate-key="blog_config_audit_intro">L'objectif est de dresser une cartographie fiable des performances en moins de quinze jours. La démarche se structure autour de trois axes complémentaires qui se nourrissent l'un l'autre.</p>
                     <div class="media-grid">
                         <div class="media-card media-card--text">
-                            <h3>Mesures terrain</h3>
+                            <h3 data-translate-key="blog_config_audit_card1_title">Mesures terrain</h3>
                             <ul>
-                                <li>Journalisation des temps d'ouverture sur dix assemblages représentatifs</li>
-                                <li>Suivi CPU/GPU via SOLIDWORKS RX complété par HWinfo</li>
-                                <li>Analyse détaillée des temps de check-in/out PDM</li>
+                                <li data-translate-key="blog_config_audit_card1_item1">Journalisation des temps d'ouverture sur dix assemblages représentatifs</li>
+                                <li data-translate-key="blog_config_audit_card1_item2">Suivi CPU/GPU via SOLIDWORKS RX complété par HWinfo</li>
+                                <li data-translate-key="blog_config_audit_card1_item3">Analyse détaillée des temps de check-in/out PDM</li>
                             </ul>
                         </div>
                         <div class="media-card media-card--text">
-                            <h3>Entretien utilisateurs</h3>
+                            <h3 data-translate-key="blog_config_audit_card2_title">Entretien utilisateurs</h3>
                             <ul>
-                                <li>Cartographie des tâches critiques (assemblage, Simulation, Visualize)</li>
-                                <li>Identification des pics de charge hebdomadaires et saisonniers</li>
-                                <li>Évaluation de la maturité PDM&nbsp;: workflows, réplications, discipline documentaire</li>
+                                <li data-translate-key="blog_config_audit_card2_item1">Cartographie des tâches critiques (assemblage, Simulation, Visualize)</li>
+                                <li data-translate-key="blog_config_audit_card2_item2">Identification des pics de charge hebdomadaires et saisonniers</li>
+                                <li data-translate-key="blog_config_audit_card2_item3">Évaluation de la maturité PDM&nbsp;: workflows, réplications, discipline documentaire</li>
                             </ul>
                         </div>
                         <div class="media-card media-card--text">
-                            <h3>Inventaire IT</h3>
+                            <h3 data-translate-key="blog_config_audit_card3_title">Inventaire IT</h3>
                             <ul>
-                                <li>Âge, garantie et version de firmware des stations</li>
-                                <li>Topologie réseau, saturation des VLAN et qualité du câblage</li>
-                                <li>Stratégie de sauvegarde et PRA autour du coffre-fort PDM</li>
+                                <li data-translate-key="blog_config_audit_card3_item1">Âge, garantie et version de firmware des stations</li>
+                                <li data-translate-key="blog_config_audit_card3_item2">Topologie réseau, saturation des VLAN et qualité du câblage</li>
+                                <li data-translate-key="blog_config_audit_card3_item3">Stratégie de sauvegarde et PRA autour du coffre-fort PDM</li>
                             </ul>
                         </div>
                     </div>
                     <div class="callout callout--soft">
-                        <p><strong>Livrable clé :</strong> une matrice qui croise profils utilisateurs et workloads, assortie d'un indicateur de santé (vert / orange / rouge). Elle sert de boussole pour calibrer les investissements ciblés.</p>
+                        <p data-translate-key="blog_config_audit_callout"><strong>Livrable clé :</strong> une matrice qui croise profils utilisateurs et workloads, assortie d'un indicateur de santé (vert / orange / rouge). Elle sert de boussole pour calibrer les investissements ciblés.</p>
                     </div>
                 </section>
 
                 <section class="blog-section article-section" id="profils-workstations">
-                    <h2>3. Trois profils de stations prêts à déployer</h2>
-                    <p>Au lieu de multiplier les stations sur mesure, je préconise trois profils standardisés. Ils couvrent plus de 90&nbsp;% des cas observés, simplifient les achats et réduisent la variabilité lors des maintenances.</p>
+                    <h2 data-translate-key="blog_config_profils_title">3. Trois profils de stations prêts à déployer</h2>
+                    <p data-translate-key="blog_config_profils_intro">Au lieu de multiplier les stations sur mesure, je préconise trois profils standardisés. Ils couvrent plus de 90&nbsp;% des cas observés, simplifient les achats et réduisent la variabilité lors des maintenances.</p>
                     <table class="feature-table">
                         <thead>
                             <tr>
-                                <th>Profil</th>
-                                <th>CPU</th>
-                                <th>GPU</th>
-                                <th>RAM</th>
-                                <th>Stockage</th>
-                                <th>Usage principal</th>
+                                <th data-translate-key="blog_config_profils_table_header_profile">Profil</th>
+                                <th data-translate-key="blog_config_profils_table_header_cpu">CPU</th>
+                                <th data-translate-key="blog_config_profils_table_header_gpu">GPU</th>
+                                <th data-translate-key="blog_config_profils_table_header_ram">RAM</th>
+                                <th data-translate-key="blog_config_profils_table_header_storage">Stockage</th>
+                                <th data-translate-key="blog_config_profils_table_header_usage">Usage principal</th>
                             </tr>
                         </thead>
                         <tbody>
                             <tr>
-                                <td>Bureau d'études</td>
+                                <td data-translate-key="blog_config_profils_row1_label">Bureau d'études</td>
                                 <td>Intel Core i7-14700K</td>
                                 <td>NVIDIA RTX 4000 Ada</td>
                                 <td>64&nbsp;Go DDR5</td>
                                 <td>2&nbsp;To NVMe Gen4 + 2&nbsp;To SATA</td>
-                                <td>Assemblages &lt; 5&nbsp;000 pièces, mise en plan</td>
+                                <td data-translate-key="blog_config_profils_row1_usage">Assemblages &lt; 5&nbsp;000 pièces, mise en plan</td>
                             </tr>
                             <tr>
-                                <td>Simulation avancée</td>
+                                <td data-translate-key="blog_config_profils_row2_label">Simulation avancée</td>
                                 <td>AMD Ryzen 9 7950X</td>
                                 <td>NVIDIA RTX 5000 Ada</td>
                                 <td>128&nbsp;Go DDR5</td>
                                 <td>2&nbsp;To NVMe Gen4 (RAID 1)</td>
-                                <td>Simulation statique / thermique / Flow</td>
+                                <td data-translate-key="blog_config_profils_row2_usage">Simulation statique / thermique / Flow</td>
                             </tr>
                             <tr>
-                                <td>Revue immersive</td>
+                                <td data-translate-key="blog_config_profils_row3_label">Revue immersive</td>
                                 <td>Intel Core i9-14900KF</td>
                                 <td>NVIDIA RTX 6000 Ada</td>
                                 <td>128&nbsp;Go DDR5</td>
                                 <td>2&nbsp;To NVMe Gen4 + 4&nbsp;To SSD</td>
-                                <td>VR, Visualize, revues clients</td>
+                                <td data-translate-key="blog_config_profils_row3_usage">VR, Visualize, revues clients</td>
                             </tr>
                         </tbody>
                     </table>
                     <figure class="media-figure">
                         <img src="/assets/img/blog/configuration-materielle-solidworks/workstation-profiles.svg" alt="Illustration des trois profils de stations de travail recommandés pour SOLIDWORKS" loading="lazy">
-                        <figcaption>Trois profils éprouvés sur le terrain&nbsp;: budget maîtrisé, maintenance prévisible et gains visibles dès les premières semaines.</figcaption>
+                        <figcaption data-translate-key="blog_config_profils_figcaption">Trois profils éprouvés sur le terrain&nbsp;: budget maîtrisé, maintenance prévisible et gains visibles dès les premières semaines.</figcaption>
                     </figure>
                     <figure class="chart-figure" data-blog-chart>
                         <canvas aria-label="Comparatif de charge selon les profils de stations"></canvas>
@@ -279,59 +279,59 @@
                         </script>
                     </figure>
                     <div class="callout">
-                        <p><strong>Astuce terrain :</strong> préparez des images Windows différenciées (Design, Simulation, VR) avec politiques d'alimentation adaptées. Vous évitez les BIOS sous-optimisés et sécurisez un comportement homogène sur tout le parc.</p>
+                        <p data-translate-key="blog_config_profils_callout"><strong>Astuce terrain :</strong> préparez des images Windows différenciées (Design, Simulation, VR) avec politiques d'alimentation adaptées. Vous évitez les BIOS sous-optimisés et sécurisez un comportement homogène sur tout le parc.</p>
                     </div>
                 </section>
 
                 <section class="blog-section article-section" id="infrastructure">
-                    <h2>4. Serveur PDM, stockage et réseau</h2>
-                    <p>Une station de travail performante ne suffit pas si le coffre-fort PDM ou le réseau devient le nouveau goulot d'étranglement. Les projets les plus fluides reposent sur une architecture complète&nbsp;: serveur applicatif dimensionné, stockage NVMe répliqué et réseau 10&nbsp;GbE qui priorise les flux CAO.</p>
+                    <h2 data-translate-key="blog_config_infra_title">4. Serveur PDM, stockage et réseau</h2>
+                    <p data-translate-key="blog_config_infra_intro">Une station de travail performante ne suffit pas si le coffre-fort PDM ou le réseau devient le nouveau goulot d'étranglement. Les projets les plus fluides reposent sur une architecture complète&nbsp;: serveur applicatif dimensionné, stockage NVMe répliqué et réseau 10&nbsp;GbE qui priorise les flux CAO.</p>
                     <figure class="media-figure">
                         <img src="/assets/img/blog/configuration-materielle-solidworks/network-backbone.svg" alt="Schéma d'une architecture matérielle SolidWorks PDM avec stockage NVMe et sauvegarde 3-2-1" loading="lazy">
-                        <figcaption>Backbone PDM prêt pour la montée en charge&nbsp;: NVMe en production, sauvegarde 3-2-1 et qualité de service appliquée aux flux critiques.</figcaption>
+                        <figcaption data-translate-key="blog_config_infra_figcaption">Backbone PDM prêt pour la montée en charge&nbsp;: NVMe en production, sauvegarde 3-2-1 et qualité de service appliquée aux flux critiques.</figcaption>
                     </figure>
                     <div class="grid grid--2">
                         <div>
-                            <h3>Serveur PDM</h3>
+                            <h3 data-translate-key="blog_config_infra_server_title">Serveur PDM</h3>
                             <ul>
-                                <li>CPU Xeon Silver ou AMD EPYC avec 12&nbsp;coeurs minimum</li>
-                                <li>128&nbsp;Go de RAM ECC pour absorber les pics de réplication</li>
-                                <li>Volumes NVMe en RAID&nbsp;1 pour le vault et SSD SATA pour les archives</li>
+                                <li data-translate-key="blog_config_infra_server_item1">CPU Xeon Silver ou AMD EPYC avec 12&nbsp;coeurs minimum</li>
+                                <li data-translate-key="blog_config_infra_server_item2">128&nbsp;Go de RAM ECC pour absorber les pics de réplication</li>
+                                <li data-translate-key="blog_config_infra_server_item3">Volumes NVMe en RAID&nbsp;1 pour le vault et SSD SATA pour les archives</li>
                             </ul>
                         </div>
                         <div>
-                            <h3>Réseau &amp; QoS</h3>
+                            <h3 data-translate-key="blog_config_infra_network_title">Réseau &amp; QoS</h3>
                             <ul>
-                                <li>Backbone 10&nbsp;GbE redondé, VLAN dédié aux flux CAO</li>
-                                <li>QoS priorisant PDM, Visualize et sauvegardes différées</li>
-                                <li>VPN avec compression et cache local pour les sites distants</li>
+                                <li data-translate-key="blog_config_infra_network_item1">Backbone 10&nbsp;GbE redondé, VLAN dédié aux flux CAO</li>
+                                <li data-translate-key="blog_config_infra_network_item2">QoS priorisant PDM, Visualize et sauvegardes différées</li>
+                                <li data-translate-key="blog_config_infra_network_item3">VPN avec compression et cache local pour les sites distants</li>
                             </ul>
                         </div>
                     </div>
                     <div class="chart-card" data-blog-chart data-chart-type="doughnut" data-chart-labels="Workstations,Serveur PDM,Stockage,Sauvegarde,Réseau" data-chart-values="45,18,14,10,13" data-chart-dataset-label="Répartition budget matériel" data-chart-options='{"plugins":{"legend":{"position":"bottom"}}}'>
-                        <p>Répartition indicative d'un budget de modernisation (en&nbsp;%). Ajustez-la à l'issue de votre audit&nbsp;: les gains rapides proviennent souvent du stockage et du réseau.</p>
+                        <p data-translate-key="blog_config_infra_chart_text">Répartition indicative d'un budget de modernisation (en&nbsp;%). Ajustez-la à l'issue de votre audit&nbsp;: les gains rapides proviennent souvent du stockage et du réseau.</p>
                     </div>
                     <div class="callout callout--soft">
-                        <p><strong>Point de vigilance :</strong> synchronisez vos maintenances avec les cycles de sauvegarde et institutionnalisez un test mensuel de restauration du coffre-fort. Un PRA documenté évite les arrêts de production lors des mises à jour SOLIDWORKS.</p>
+                        <p data-translate-key="blog_config_infra_callout"><strong>Point de vigilance :</strong> synchronisez vos maintenances avec les cycles de sauvegarde et institutionnalisez un test mensuel de restauration du coffre-fort. Un PRA documenté évite les arrêts de production lors des mises à jour SOLIDWORKS.</p>
                     </div>
                 </section>
 
                 <section class="blog-section article-section" id="plan-daction">
-                    <h2>5. Plan d'action 90 jours</h2>
-                    <p>Une fois la cible validée, structurez la mise en œuvre en trois sprints de trente jours. Objectif&nbsp;: livrer des améliorations visibles dès le premier mois tout en sécurisant la trajectoire long terme.</p>
+                    <h2 data-translate-key="blog_config_plan_title">5. Plan d'action 90 jours</h2>
+                    <p data-translate-key="blog_config_plan_intro">Une fois la cible validée, structurez la mise en œuvre en trois sprints de trente jours. Objectif&nbsp;: livrer des améliorations visibles dès le premier mois tout en sécurisant la trajectoire long terme.</p>
                     <ol>
-                        <li><strong>Sprint&nbsp;1&nbsp;:</strong> commandes et quick wins (SSD NVMe, BIOS à jour, tuning Windows). KPI&nbsp;: temps d'ouverture moyen &lt;&nbsp;45&nbsp;secondes.</li>
-                        <li><strong>Sprint&nbsp;2&nbsp;:</strong> déploiement des nouvelles stations et mise à niveau réseau. KPI&nbsp;: zéro erreur de check-in PDM, latence moyenne &lt;&nbsp;2&nbsp;ms.</li>
-                        <li><strong>Sprint&nbsp;3&nbsp;:</strong> bascule serveur PDM, sauvegarde 3-2-1, formation utilisateurs. KPI&nbsp;: satisfaction utilisateurs &gt;&nbsp;8/10, PRA testé et validé.</li>
+                        <li data-translate-key="blog_config_plan_item1"><strong>Sprint&nbsp;1&nbsp;:</strong> commandes et quick wins (SSD NVMe, BIOS à jour, tuning Windows). KPI&nbsp;: temps d'ouverture moyen &lt;&nbsp;45&nbsp;secondes.</li>
+                        <li data-translate-key="blog_config_plan_item2"><strong>Sprint&nbsp;2&nbsp;:</strong> déploiement des nouvelles stations et mise à niveau réseau. KPI&nbsp;: zéro erreur de check-in PDM, latence moyenne &lt;&nbsp;2&nbsp;ms.</li>
+                        <li data-translate-key="blog_config_plan_item3"><strong>Sprint&nbsp;3&nbsp;:</strong> bascule serveur PDM, sauvegarde 3-2-1, formation utilisateurs. KPI&nbsp;: satisfaction utilisateurs &gt;&nbsp;8/10, PRA testé et validé.</li>
                     </ol>
-                    <p>Ce plan permet d'engranger des gains dès le premier mois tout en alignant IT, bureau d'études et direction industrielle sur la même feuille de route.</p>
+                    <p data-translate-key="blog_config_plan_outro">Ce plan permet d'engranger des gains dès le premier mois tout en alignant IT, bureau d'études et direction industrielle sur la même feuille de route.</p>
                 </section>
 
                 <section class="blog-section article-cta" data-component="cta">
                     <div class="cta-card">
-                        <h2>Vous voulez fiabiliser votre environnement SOLIDWORKS&nbsp;?</h2>
-                        <p>Je vous aide à cadrer l'audit, hiérarchiser les investissements et orchestrer le déploiement sans interrompre la production. Discutons de vos priorités.</p>
-                        <a class="hero-btn" href="/#contact">Planifier un échange</a>
+                        <h2 data-translate-key="blog_config_cta_title">Vous voulez fiabiliser votre environnement SOLIDWORKS&nbsp;?</h2>
+                        <p data-translate-key="blog_config_cta_text">Je vous aide à cadrer l'audit, hiérarchiser les investissements et orchestrer le déploiement sans interrompre la production. Discutons de vos priorités.</p>
+                        <a class="hero-btn" href="/#contact" data-translate-key="blog_config_cta_button">Planifier un échange</a>
                     </div>
                 </section>
             </article>

--- a/blog/index.html
+++ b/blog/index.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="/assets/css/style.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
 </head>
-<body class="blog-page">
+<body class="blog-page" data-blog-page="index">
     <canvas id="transition-canvas"></canvas>
     <div class="perspective-wrapper">
         <div id="perspective-content" class="perspective-content"></div>
@@ -33,12 +33,12 @@
             <a href="/" class="logo">M.BAOUCH</a>
             <div class="nav-right">
                 <ul class="menu" id="menu">
-                    <li><a href="/#about" class="nav-link">À propos</a></li>
-                    <li><a href="/#experience" class="nav-link">Expérience</a></li>
-                    <li><a href="/#skills" class="nav-link">Compétences</a></li>
-                    <li><a href="/#education" class="nav-link">Formation</a></li>
-                    <li><a href="/#contact" class="nav-link">Contact</a></li>
-                    <li><a href="/blog/" class="nav-link">Blog</a></li>
+                    <li><a href="/#about" class="nav-link" data-translate-key="nav_about">À propos</a></li>
+                    <li><a href="/#experience" class="nav-link" data-translate-key="nav_experience">Expérience</a></li>
+                    <li><a href="/#skills" class="nav-link" data-translate-key="nav_skills">Compétences</a></li>
+                    <li><a href="/#education" class="nav-link" data-translate-key="nav_education">Formation</a></li>
+                    <li><a href="/#contact" class="nav-link" data-translate-key="nav_contact">Contact</a></li>
+                    <li><a href="/blog/" class="nav-link" data-translate-key="nav_blog">Blog</a></li>
                 </ul>
                 <div class="language-switcher">
                     <button id="lang-fr" class="lang-btn active">FR</button>
@@ -90,37 +90,37 @@
                 <section class="blog-hero" data-hero>
   <div class="hero-intro">
     <h1 class="hero-title" data-hero-title>Configuration matérielle SOLIDWORKS 2025 : le guide terrain pour un bureau d'études réactif</h1>
-    <p class="hero-subtitle" data-hero-subtitle>Publié le 21 septembre 2025. Guide pratique de Mohamed Omar Baouch pour dimensionner stations de travail, serveur PDM et réseau autour de SOLIDWORKS 2025, avec benchmarks et feuilles de route opérationnelles.</p>
+    <p class="hero-subtitle" data-hero-subtitle>Publié le <span data-date-iso="2025-09-21T00:00:00.000Z" data-date-format="long">21 septembre 2025</span>. Guide pratique de Mohamed Omar Baouch pour dimensionner stations de travail, serveur PDM et réseau autour de SOLIDWORKS 2025, avec benchmarks et feuilles de route opérationnelles.</p>
     <div class="hero-actions">
       <a class="hero-btn" data-hero-link href="/blog/configuration-materielle-solidworks/">Lire l'article</a>
     </div>
   </div>
 </section><section class="blog-controls">
   <div class="filter-group" data-filter-group role="group" aria-label="Filtrer les contenus du blog">
-    <button class="filter-btn is-active" type="button" data-filter="all" aria-pressed="true">Tout</button>
-    <button class="filter-btn" type="button" data-filter="editorial" aria-pressed="false">Articles de fond</button>
+    <button class="filter-btn is-active" type="button" data-filter="all" aria-pressed="true" data-translate-key="blog_index_filter_all">Tout</button>
+    <button class="filter-btn" type="button" data-filter="editorial" aria-pressed="false" data-translate-key="blog_index_filter_editorial">Articles de fond</button>
   </div>
 </section>
 
 <section class="blog-section" data-section="editorial">
   <div class="section-header">
-    <h2>Articles de fond</h2>
-    <p class="section-subtitle">Analyses éditoriales, retours d’expérience et bonnes pratiques terrain.</p>
+    <h2 data-translate-key="blog_index_section_editorial_title">Articles de fond</h2>
+    <p class="section-subtitle" data-translate-key="blog_index_section_editorial_subtitle">Analyses éditoriales, retours d’expérience et bonnes pratiques terrain.</p>
   </div>
-  <div class="card-grid"><article class="post-card" data-type="editorial">
+  <div class="card-grid"><article class="post-card" data-type="editorial" data-post-slug="configuration-materielle-solidworks">
   <div class="post-card__meta">
-    <span class="badge badge-editorial">Article de fond</span>
-    <time datetime="2025-09-21T00:00:00.000Z">21 septembre 2025</time>
-    
+    <span class="badge badge-editorial" data-translate-key="blog_badge_editorial">Article de fond</span>
+    <time datetime="2025-09-21T00:00:00.000Z" data-date-format="long" data-date-iso="2025-09-21T00:00:00.000Z">21 septembre 2025</time>
+
   </div>
   <h3 class="post-card__title"><a href="/blog/configuration-materielle-solidworks/">Configuration matérielle SOLIDWORKS 2025 : le guide terrain pour un bureau d&#39;études réactif</a></h3>
   <p class="post-card__excerpt">Guide pratique de Mohamed Omar Baouch pour dimensionner stations de travail, serveur PDM et réseau autour de SOLIDWORKS 2025, avec benchmarks et feuilles de route opérationnelles.</p>
   <a class="post-card__cta" href="/blog/configuration-materielle-solidworks/">Lire l'article</a>
-</article><article class="post-card" data-type="editorial">
+</article><article class="post-card" data-type="editorial" data-post-slug="resolutions-problematiques-plm">
   <div class="post-card__meta">
-    <span class="badge badge-editorial">Article de fond</span>
-    <time datetime="2025-09-15T00:00:00.000Z">15 septembre 2025</time>
-    
+    <span class="badge badge-editorial" data-translate-key="blog_badge_editorial">Article de fond</span>
+    <time datetime="2025-09-15T00:00:00.000Z" data-date-format="long" data-date-iso="2025-09-15T00:00:00.000Z">15 septembre 2025</time>
+
   </div>
   <h3 class="post-card__title"><a href="/blog/resolutions-problematiques-plm/">Au-delà de la théorie : résoudre les 5 problématiques PLM que j&#39;ai vécues en tant qu&#39;Ingénieur Mécanique</a></h3>
   <p class="post-card__excerpt">Retour d</p>
@@ -134,36 +134,62 @@
   "generatedAt": "2025-09-21T19:15:20.844Z",
   "hero": {
     "editorialHighlight": {
-      "title": "Configuration matérielle SOLIDWORKS 2025 : le guide terrain pour un bureau d'études réactif",
+      "title": {
+        "fr": "Configuration matérielle SOLIDWORKS 2025 : le guide terrain pour un bureau d'études réactif",
+        "en": "SOLIDWORKS 2025 hardware configuration: the field guide for an agile design office"
+      },
       "url": "/blog/configuration-materielle-solidworks/",
       "dateIso": "2025-09-21T00:00:00.000Z",
-      "displayDate": "21 septembre 2025",
-      "shortDate": "21/09/2025",
-      "excerpt": "Guide pratique de Mohamed Omar Baouch pour dimensionner stations de travail, serveur PDM et réseau autour de SOLIDWORKS 2025, avec benchmarks et feuilles de route opérationnelles.",
-      "heroSubtitle": "Publié le 21 septembre 2025. Guide pratique de Mohamed Omar Baouch pour dimensionner stations de travail, serveur PDM et réseau autour de SOLIDWORKS 2025, avec benchmarks et feuilles de route opérationnelles.",
+      "excerpt": {
+        "fr": "Guide pratique de Mohamed Omar Baouch pour dimensionner stations de travail, serveur PDM et réseau autour de SOLIDWORKS 2025, avec benchmarks et feuilles de route opérationnelles.",
+        "en": "Practical guide by Mohamed Omar Baouch to size workstations, the PDM server, and the network around SOLIDWORKS 2025, with benchmarks and actionable roadmaps."
+      },
+      "heroSubtitle": {
+        "fr": "Publié le <span data-date-iso=\"2025-09-21T00:00:00.000Z\" data-date-format=\"long\"></span>. Guide pratique de Mohamed Omar Baouch pour dimensionner stations de travail, serveur PDM et réseau autour de SOLIDWORKS 2025, avec benchmarks et feuilles de route opérationnelles.",
+        "en": "Published on <span data-date-iso=\"2025-09-21T00:00:00.000Z\" data-date-format=\"long\"></span>. Practical guide by Mohamed Omar Baouch to size workstations, the PDM server, and the network around SOLIDWORKS 2025, with benchmarks and actionable roadmaps."
+      },
       "type": "editorial",
-      "ctaLabel": "Lire l'article"
+      "ctaLabel": {
+        "fr": "Lire l'article",
+        "en": "Read the article"
+      }
     }
   },
   "editorials": [
     {
       "slug": "configuration-materielle-solidworks",
       "url": "/blog/configuration-materielle-solidworks/",
-      "title": "Configuration matérielle SOLIDWORKS 2025 : le guide terrain pour un bureau d'études réactif",
+      "title": {
+        "fr": "Configuration matérielle SOLIDWORKS 2025 : le guide terrain pour un bureau d'études réactif",
+        "en": "SOLIDWORKS 2025 hardware configuration: the field guide for an agile design office"
+      },
       "dateIso": "2025-09-21T00:00:00.000Z",
-      "displayDate": "21 septembre 2025",
-      "shortDate": "21/09/2025",
-      "excerpt": "Guide pratique de Mohamed Omar Baouch pour dimensionner stations de travail, serveur PDM et réseau autour de SOLIDWORKS 2025, avec benchmarks et feuilles de route opérationnelles.",
+      "excerpt": {
+        "fr": "Guide pratique de Mohamed Omar Baouch pour dimensionner stations de travail, serveur PDM et réseau autour de SOLIDWORKS 2025, avec benchmarks et feuilles de route opérationnelles.",
+        "en": "Practical guide by Mohamed Omar Baouch to size workstations, the PDM server, and the network around SOLIDWORKS 2025, with benchmarks and actionable roadmaps."
+      },
+      "ctaLabel": {
+        "fr": "Lire l'article",
+        "en": "Read the article"
+      },
       "type": "editorial"
     },
     {
       "slug": "resolutions-problematiques-plm",
       "url": "/blog/resolutions-problematiques-plm/",
-      "title": "Au-delà de la théorie : résoudre les 5 problématiques PLM que j'ai vécues en tant qu'Ingénieur Mécanique",
+      "title": {
+        "fr": "Au-delà de la théorie : résoudre les 5 problématiques PLM que j'ai vécues en tant qu'Ingénieur Mécanique",
+        "en": "Beyond theory: solving the 5 PLM challenges I experienced as a Mechanical Engineer"
+      },
       "dateIso": "2025-09-15T00:00:00.000Z",
-      "displayDate": "15 septembre 2025",
-      "shortDate": "15/09/2025",
-      "excerpt": "Retour d'expérience sur la résolution de problématiques PLM vécues sur le terrain.",
+      "excerpt": {
+        "fr": "Retour d'expérience sur la résolution de problématiques PLM vécues sur le terrain.",
+        "en": "Field feedback on resolving PLM challenges encountered on the ground."
+      },
+      "ctaLabel": {
+        "fr": "Lire l'article",
+        "en": "Read the article"
+      },
       "type": "editorial"
     }
   ]

--- a/blog/resolutions-problematiques-plm/index.html
+++ b/blog/resolutions-problematiques-plm/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="/assets/css/style.css">
     <link rel="stylesheet" href="/assets/css/blog.css">
 </head>
-<body class="blog-page">
+<body class="blog-page" data-blog-post="resolutions-problematiques-plm">
     <canvas id="transition-canvas"></canvas>
     <div class="perspective-wrapper">
         <div id="perspective-content" class="perspective-content"></div>
@@ -33,12 +33,12 @@
             <a href="/" class="logo">M.BAOUCH</a>
             <div class="nav-right">
                 <ul class="menu" id="menu">
-                    <li><a href="/#about" class="nav-link">À propos</a></li>
-                    <li><a href="/#experience" class="nav-link">Expérience</a></li>
-                    <li><a href="/#skills" class="nav-link">Compétences</a></li>
-                    <li><a href="/#education" class="nav-link">Formation</a></li>
-                    <li><a href="/#contact" class="nav-link">Contact</a></li>
-                    <li><a href="/blog/" class="nav-link">Blog</a></li>
+                    <li><a href="/#about" class="nav-link" data-translate-key="nav_about">À propos</a></li>
+                    <li><a href="/#experience" class="nav-link" data-translate-key="nav_experience">Expérience</a></li>
+                    <li><a href="/#skills" class="nav-link" data-translate-key="nav_skills">Compétences</a></li>
+                    <li><a href="/#education" class="nav-link" data-translate-key="nav_education">Formation</a></li>
+                    <li><a href="/#contact" class="nav-link" data-translate-key="nav_contact">Contact</a></li>
+                    <li><a href="/blog/" class="nav-link" data-translate-key="nav_blog">Blog</a></li>
                 </ul>
                 <div class="language-switcher">
                     <button id="lang-fr" class="lang-btn active">FR</button>
@@ -57,187 +57,187 @@
         <div class="blog-shell" id="blogShell" data-shell>
             <article class="blog-article" data-article-root>
                 <nav class="article-breadcrumbs" aria-label="Navigation secondaire">
-                    <a class="back-link" href="/blog/">← Retour au blog</a>
-                    <a class="back-link back-link--ghost" href="/">Retour au portfolio</a>
+                    <a class="back-link" href="/blog/" data-translate-key="blog_back_to_blog">← Retour au blog</a>
+                    <a class="back-link back-link--ghost" href="/" data-translate-key="blog_back_to_portfolio">Retour au portfolio</a>
                 </nav>
 
                 <header class="blog-hero post-hero" data-component="hero">
                     <div class="hero-intro">
                         <div class="hero-badges">
-                            <span class="badge badge-editorial">Article de fond</span>
+                            <span class="badge badge-editorial" data-translate-key="blog_badge_editorial">Article de fond</span>
                         </div>
-                        <span class="hero-eyebrow">Expérience terrain</span>
-                        <h1 class="hero-title">Au-delà de la théorie : résoudre les 5 problématiques PLM que j'ai vécues en tant qu'Ingénieur Mécanique</h1>
-                        <p class="hero-subtitle">Retour d'expérience publié le 15 septembre 2025 : comment passer des discours aux actions concrètes pour sécuriser données, nomenclatures et collaboration.</p>
+                        <span class="hero-eyebrow" data-translate-key="blog_plm_hero_eyebrow">Expérience terrain</span>
+                        <h1 class="hero-title" data-translate-key="blog_plm_hero_title">Au-delà de la théorie : résoudre les 5 problématiques PLM que j'ai vécues en tant qu'Ingénieur Mécanique</h1>
+                        <p class="hero-subtitle" data-translate-key="blog_plm_hero_subtitle">Retour d'expérience publié le <span data-date-iso="2025-09-15T00:00:00.000Z" data-date-format="long">15 septembre 2025</span> : comment passer des discours aux actions concrètes pour sécuriser données, nomenclatures et collaboration.</p>
                         <div class="hero-actions">
-                            <a class="hero-btn" href="#sommaire">Consulter le sommaire</a>
-                            <a class="hero-btn hero-btn--ghost" href="/#contact">Discuter de votre projet</a>
+                            <a class="hero-btn" href="#sommaire" data-translate-key="blog_cta_summary">Consulter le sommaire</a>
+                            <a class="hero-btn hero-btn--ghost" href="/#contact" data-translate-key="blog_cta_discuss_project">Discuter de votre projet</a>
                         </div>
                     </div>
                     <div class="hero-stats">
                         <div class="hero-stat">
-                            <span class="hero-stat-value">15/09/2025</span>
-                            <span class="hero-stat-label">Date de publication</span>
+                            <span class="hero-stat-value" data-date-iso="2025-09-15T00:00:00.000Z" data-date-format="short">15/09/2025</span>
+                            <span class="hero-stat-label" data-translate-key="blog_plm_stat_publication">Date de publication</span>
                         </div>
                         <div class="hero-stat">
                             <span class="hero-stat-value">5</span>
-                            <span class="hero-stat-label">Problématiques traitées</span>
+                            <span class="hero-stat-label" data-translate-key="blog_plm_stat_issues">Problématiques traitées</span>
                         </div>
                         <div class="hero-stat">
                             <span class="hero-stat-value">Visiativ</span>
-                            <span class="hero-stat-label">Expertise terrain</span>
+                            <span class="hero-stat-label" data-translate-key="blog_plm_stat_expertise">Expertise terrain</span>
                         </div>
                     </div>
                 </header>
 
                 <nav class="blog-section article-summary" id="sommaire" aria-label="Sommaire de l'article">
-                    <h2 class="summary-title">Sommaire</h2>
+                    <h2 class="summary-title" data-translate-key="blog_summary_title">Sommaire</h2>
                     <ol class="summary-list">
                         <li>
                             <a href="#silos-donnees">
                                 <span class="summary-index">01</span>
-                                <span class="summary-label">Silos de données qui fragmentent le savoir</span>
-                                <span class="summary-meta">De l'enquête manuelle au coffre-fort PDM</span>
+                                <span class="summary-label" data-translate-key="blog_plm_summary_label1">Silos de données qui fragmentent le savoir</span>
+                                <span class="summary-meta" data-translate-key="blog_plm_summary_meta1">De l'enquête manuelle au coffre-fort PDM</span>
                             </a>
                         </li>
                         <li>
                             <a href="#erreurs-nomenclatures">
                                 <span class="summary-index">02</span>
-                                <span class="summary-label">Erreurs dans les nomenclatures</span>
-                                <span class="summary-meta">Quand Excel fait dérailler la production</span>
+                                <span class="summary-label" data-translate-key="blog_plm_summary_label2">Erreurs dans les nomenclatures</span>
+                                <span class="summary-meta" data-translate-key="blog_plm_summary_meta2">Quand Excel fait dérailler la production</span>
                             </a>
                         </li>
                         <li>
                             <a href="#versions-incontrolees">
                                 <span class="summary-index">03</span>
-                                <span class="summary-label">Versions incontrôlées et confusion</span>
-                                <span class="summary-meta">Le risque caché des dossiers « finale_v3 »</span>
+                                <span class="summary-label" data-translate-key="blog_plm_summary_label3">Versions incontrôlées et confusion</span>
+                                <span class="summary-meta" data-translate-key="blog_plm_summary_meta3">Le risque caché des dossiers « finale_v3 »</span>
                             </a>
                         </li>
                         <li>
                             <a href="#collaboration-freinee">
                                 <span class="summary-index">04</span>
-                                <span class="summary-label">Collaboration freinée entre BE et production</span>
-                                <span class="summary-meta">Du mail perdu au workflow tracé</span>
+                                <span class="summary-label" data-translate-key="blog_plm_summary_label4">Collaboration freinée entre BE et production</span>
+                                <span class="summary-meta" data-translate-key="blog_plm_summary_meta4">Du mail perdu au workflow tracé</span>
                             </a>
                         </li>
                         <li>
                             <a href="#tracabilite-conformite">
                                 <span class="summary-index">05</span>
-                                <span class="summary-label">Traçabilité et conformité sous tension</span>
-                                <span class="summary-meta">Répondre à un audit en quelques clics</span>
+                                <span class="summary-label" data-translate-key="blog_plm_summary_label5">Traçabilité et conformité sous tension</span>
+                                <span class="summary-meta" data-translate-key="blog_plm_summary_meta5">Répondre à un audit en quelques clics</span>
                             </a>
                         </li>
                     </ol>
                 </nav>
 
                 <section class="blog-section article-section">
-                    <p>Quand j'ai débuté comme ingénieur mécanique, la gestion des données produit me semblait un sujet réservé aux grandes entreprises et aux théoriciens des processus. La réalité du terrain m'a vite montré l'inverse. Chez Evolum puis chez ABMI, j'ai vu comment un simple plan mal versionné pouvait immobiliser une ligne de production ou comment une nomenclature erronée pouvait faire exploser les coûts d'un projet.</p>
+                    <p data-translate-key="blog_plm_intro_p1">Quand j'ai débuté comme ingénieur mécanique, la gestion des données produit me semblait un sujet réservé aux grandes entreprises et aux théoriciens des processus. La réalité du terrain m'a vite montré l'inverse. Chez Evolum puis chez ABMI, j'ai vu comment un simple plan mal versionné pouvait immobiliser une ligne de production ou comment une nomenclature erronée pouvait faire exploser les coûts d'un projet.</p>
                     <div class="callout">
                         <div class="quote-block">
-                            <blockquote>Un PDM/PLM bien implémenté n'est pas un luxe : c'est un filet de sécurité qui libère les équipes de la chasse aux informations pour qu'elles se concentrent sur l'innovation.</blockquote>
-                            <cite>Mohamed Omar Baouch</cite>
+                            <blockquote data-translate-key="blog_plm_intro_quote">Un PDM/PLM bien implémenté n'est pas un luxe : c'est un filet de sécurité qui libère les équipes de la chasse aux informations pour qu'elles se concentrent sur l'innovation.</blockquote>
+                            <cite data-translate-key="blog_plm_intro_author">Mohamed Omar Baouch</cite>
                         </div>
                     </div>
-                    <p>Au fil des projets, j'ai identifié cinq problématiques récurrentes. Elles ne sont pas théoriques : chacune est issue d'un incident concret, d'un retard de production ou d'un audit stressant. Voici la synthèse des symptômes et des réponses mises en place avec les équipes terrain.</p>
+                    <p data-translate-key="blog_plm_intro_p2">Au fil des projets, j'ai identifié cinq problématiques récurrentes. Elles ne sont pas théoriques : chacune est issue d'un incident concret, d'un retard de production ou d'un audit stressant. Voici la synthèse des symptômes et des réponses mises en place avec les équipes terrain.</p>
                     <table class="feature-table">
                         <thead>
                             <tr>
-                                <th>Problématique</th>
-                                <th>Impact terrain</th>
-                                <th>Solution PLM appliquée</th>
+                                <th data-translate-key="blog_plm_table_header_issue">Problématique</th>
+                                <th data-translate-key="blog_plm_table_header_impact">Impact terrain</th>
+                                <th data-translate-key="blog_plm_table_header_solution">Solution PLM appliquée</th>
                             </tr>
                         </thead>
                         <tbody>
                             <tr>
-                                <td>Silos de données</td>
-                                <td>Temps perdu à retrouver la bonne version</td>
-                                <td>Coffre-fort PDM centralisé et droits maîtrisés</td>
+                                <td data-translate-key="blog_plm_table_row1_issue">Silos de données</td>
+                                <td data-translate-key="blog_plm_table_row1_impact">Temps perdu à retrouver la bonne version</td>
+                                <td data-translate-key="blog_plm_table_row1_solution">Coffre-fort PDM centralisé et droits maîtrisés</td>
                             </tr>
                             <tr>
-                                <td>Nomenclatures instables</td>
-                                <td>Achats erronés, prototypes retardés</td>
-                                <td>Génération automatique des BOM depuis la CAO</td>
+                                <td data-translate-key="blog_plm_table_row2_issue">Nomenclatures instables</td>
+                                <td data-translate-key="blog_plm_table_row2_impact">Achats erronés, prototypes retardés</td>
+                                <td data-translate-key="blog_plm_table_row2_solution">Génération automatique des BOM depuis la CAO</td>
                             </tr>
                             <tr>
-                                <td>Versions incontrôlées</td>
-                                <td>Production lancée sur un plan obsolète</td>
-                                <td>Gestion des révisions et workflow de validation</td>
+                                <td data-translate-key="blog_plm_table_row3_issue">Versions incontrôlées</td>
+                                <td data-translate-key="blog_plm_table_row3_impact">Production lancée sur un plan obsolète</td>
+                                <td data-translate-key="blog_plm_table_row3_solution">Gestion des révisions et workflow de validation</td>
                             </tr>
                             <tr>
-                                <td>Collaboration freinée</td>
-                                <td>Feedback perdu entre mail et atelier</td>
-                                <td>Workflows intégrés entre BE et production</td>
+                                <td data-translate-key="blog_plm_table_row4_issue">Collaboration freinée</td>
+                                <td data-translate-key="blog_plm_table_row4_impact">Feedback perdu entre mail et atelier</td>
+                                <td data-translate-key="blog_plm_table_row4_solution">Workflows intégrés entre BE et production</td>
                             </tr>
                             <tr>
-                                <td>Traçabilité fragile</td>
-                                <td>Audits retardés, confiance client fragilisée</td>
-                                <td>Historique complet et généalogie des pièces</td>
+                                <td data-translate-key="blog_plm_table_row5_issue">Traçabilité fragile</td>
+                                <td data-translate-key="blog_plm_table_row5_impact">Audits retardés, confiance client fragilisée</td>
+                                <td data-translate-key="blog_plm_table_row5_solution">Historique complet et généalogie des pièces</td>
                             </tr>
                         </tbody>
                     </table>
                 </section>
 
                 <section class="blog-section article-section" id="silos-donnees">
-                    <h2>1. Silos de données qui fragmentent le savoir</h2>
-                    <p>À mes débuts chez Evolum, chacun travaillait dans son coin. Les fichiers de conception étaient dispersés entre des disques partagés, des clés USB et parfois des ordinateurs personnels. Lorsque je devais reprendre un projet, je passais plus de temps à chercher la bonne version d'un assemblage qu'à concevoir.</p>
-                    <p>Cette fragmentation du savoir faisait perdre un temps précieux et créait des divergences entre les bureaux d'études et l'atelier. La mise en place d'un coffre-fort PDM centralisé a été une révélation : chaque modèle était stocké une seule fois, les droits d'accès étaient clairs et je pouvais retracer l'historique complet d'une pièce sans lever de téléphone.</p>
+                    <h2 data-translate-key="blog_plm_silos_title">1. Silos de données qui fragmentent le savoir</h2>
+                    <p data-translate-key="blog_plm_silos_p1">À mes débuts chez Evolum, chacun travaillait dans son coin. Les fichiers de conception étaient dispersés entre des disques partagés, des clés USB et parfois des ordinateurs personnels. Lorsque je devais reprendre un projet, je passais plus de temps à chercher la bonne version d'un assemblage qu'à concevoir.</p>
+                    <p data-translate-key="blog_plm_silos_p2">Cette fragmentation du savoir faisait perdre un temps précieux et créait des divergences entre les bureaux d'études et l'atelier. La mise en place d'un coffre-fort PDM centralisé a été une révélation : chaque modèle était stocké une seule fois, les droits d'accès étaient clairs et je pouvais retracer l'historique complet d'une pièce sans lever de téléphone.</p>
                     <div class="callout callout--soft">
-                        <p><strong>Clé du succès :</strong> rendre le PDM incontournable en l'intégrant dans les habitudes quotidiennes (check-in/check-out, commentaires, workflows de revue).</p>
+                        <p data-translate-key="blog_plm_silos_callout"><strong>Clé du succès :</strong> rendre le PDM incontournable en l'intégrant dans les habitudes quotidiennes (check-in/check-out, commentaires, workflows de revue).</p>
                     </div>
                 </section>
 
                 <section class="blog-section article-section" id="erreurs-nomenclatures">
-                    <h2>2. Erreurs dans les nomenclatures</h2>
-                    <p>Lors d'une mission chez ABMI, j'ai vécu les conséquences d'une nomenclature gérée sous Excel. Une ligne oubliée a entraîné l'achat de pièces supplémentaires et plusieurs jours de retard sur un prototype. C'est à ce moment que j'ai compris l'importance d'un système PLM capable de générer des nomenclatures cohérentes directement depuis la CAO et de les lier aux achats.</p>
+                    <h2 data-translate-key="blog_plm_nomenclature_title">2. Erreurs dans les nomenclatures</h2>
+                    <p data-translate-key="blog_plm_nomenclature_p1">Lors d'une mission chez ABMI, j'ai vécu les conséquences d'une nomenclature gérée sous Excel. Une ligne oubliée a entraîné l'achat de pièces supplémentaires et plusieurs jours de retard sur un prototype. C'est à ce moment que j'ai compris l'importance d'un système PLM capable de générer des nomenclatures cohérentes directement depuis la CAO et de les lier aux achats.</p>
                     <div class="media-grid">
                         <div class="media-card media-card--text">
-                            <h3>Avant</h3>
+                            <h3 data-translate-key="blog_plm_nomenclature_before_title">Avant</h3>
                             <ul>
-                                <li>Excel partagé par mail</li>
-                                <li>Versions multiples sans historique</li>
-                                <li>Décisions prises hors système</li>
+                                <li data-translate-key="blog_plm_nomenclature_before_item1">Excel partagé par mail</li>
+                                <li data-translate-key="blog_plm_nomenclature_before_item2">Versions multiples sans historique</li>
+                                <li data-translate-key="blog_plm_nomenclature_before_item3">Décisions prises hors système</li>
                             </ul>
                         </div>
                         <div class="media-card media-card--text">
-                            <h3>Après</h3>
+                            <h3 data-translate-key="blog_plm_nomenclature_after_title">Après</h3>
                             <ul>
-                                <li>BOM générée automatiquement</li>
-                                <li>Validation croisée avec les achats</li>
-                                <li>Historique des modifications consolidé</li>
+                                <li data-translate-key="blog_plm_nomenclature_after_item1">BOM générée automatiquement</li>
+                                <li data-translate-key="blog_plm_nomenclature_after_item2">Validation croisée avec les achats</li>
+                                <li data-translate-key="blog_plm_nomenclature_after_item3">Historique des modifications consolidé</li>
                             </ul>
                         </div>
                     </div>
-                    <p>Avec SolidWorks PDM, nous avons automatisé l'extraction des BOM et mis en place des règles de validation qui ont supprimé ce type d'erreurs. L'équipe projet gagnait en sérénité et les réunions ne tournaient plus autour de la question « qui possède la bonne version ? ».</p>
+                    <p data-translate-key="blog_plm_nomenclature_p2">Avec SolidWorks PDM, nous avons automatisé l'extraction des BOM et mis en place des règles de validation qui ont supprimé ce type d'erreurs. L'équipe projet gagnait en sérénité et les réunions ne tournaient plus autour de la question « qui possède la bonne version ? ».</p>
                 </section>
 
                 <section class="blog-section article-section" id="versions-incontrolees">
-                    <h2>3. Versions incontrôlées et confusion</h2>
-                    <p>Avant d'adopter un PDM, la gestion des révisions se résumait à des suffixes dans les noms de fichiers. Il n'était pas rare de voir des dossiers remplis de "finale", "finale2" ou "version_definitive_v3". Lors de mon passage chez Evolum, cette pratique a provoqué la fabrication d'un lot de pièces basé sur un plan obsolète.</p>
-                    <p>En implémentant un véritable PLM chez Visiativ, j'ai découvert la puissance du contrôle de versions : chaque modification est tracée, commentée et validée. Les transitions de statuts (en conception, en validation, publié) ont apporté une clarté immédiate et réduit drastiquement les allers-retours improductifs.</p>
+                    <h2 data-translate-key="blog_plm_versions_title">3. Versions incontrôlées et confusion</h2>
+                    <p data-translate-key="blog_plm_versions_p1">Avant d'adopter un PDM, la gestion des révisions se résumait à des suffixes dans les noms de fichiers. Il n'était pas rare de voir des dossiers remplis de "finale", "finale2" ou "version_definitive_v3". Lors de mon passage chez Evolum, cette pratique a provoqué la fabrication d'un lot de pièces basé sur un plan obsolète.</p>
+                    <p data-translate-key="blog_plm_versions_p2">En implémentant un véritable PLM chez Visiativ, j'ai découvert la puissance du contrôle de versions : chaque modification est tracée, commentée et validée. Les transitions de statuts (en conception, en validation, publié) ont apporté une clarté immédiate et réduit drastiquement les allers-retours improductifs.</p>
                 </section>
 
                 <section class="blog-section article-section" id="collaboration-freinee">
-                    <h2>4. Collaboration freinée entre bureaux d'études et production</h2>
-                    <p>La collaboration se limitait souvent à l'échange de fichiers par email. Les retours de l'atelier arrivaient tard et les remarques se perdaient dans les boîtes de réception. En tant que consultant chez Visiativ, j'ai accompagné plusieurs clients dans l'intégration de workflows qui relient directement la conception à la production.</p>
-                    <p>Grâce à un PDM bien configuré, l'atelier peut annoter les modèles, proposer des modifications et suivre leur prise en compte. Cette boucle de feedback en continu a transformé la relation entre les équipes et réduit drastiquement les erreurs de fabrication.</p>
+                    <h2 data-translate-key="blog_plm_collaboration_title">4. Collaboration freinée entre bureaux d'études et production</h2>
+                    <p data-translate-key="blog_plm_collaboration_p1">La collaboration se limitait souvent à l'échange de fichiers par email. Les retours de l'atelier arrivaient tard et les remarques se perdaient dans les boîtes de réception. En tant que consultant chez Visiativ, j'ai accompagné plusieurs clients dans l'intégration de workflows qui relient directement la conception à la production.</p>
+                    <p data-translate-key="blog_plm_collaboration_p2">Grâce à un PDM bien configuré, l'atelier peut annoter les modèles, proposer des modifications et suivre leur prise en compte. Cette boucle de feedback en continu a transformé la relation entre les équipes et réduit drastiquement les erreurs de fabrication.</p>
                 </section>
 
                 <section class="blog-section article-section" id="tracabilite-conformite">
-                    <h2>5. Traçabilité et conformité</h2>
-                    <p>Dans des secteurs réglementés, prouver la conformité d'un produit est aussi important que le produit lui-même. Avant l'arrivée d'un PLM, la traçabilité reposait sur des dossiers papier et la mémoire des ingénieurs. J'ai vu un audit repoussé parce qu'il était impossible de démontrer la généalogie complète d'un composant.</p>
-                    <p>Avec un PLM, chaque décision, chaque validation et chaque version est enregistrée. Lors d'un projet piloté par Visiativ, nous avons pu répondre à un audit en quelques clics, fournissant l'historique complet des modifications d'une pièce critique. La confiance du client s'en est trouvée renforcée.</p>
+                    <h2 data-translate-key="blog_plm_traceability_title">5. Traçabilité et conformité</h2>
+                    <p data-translate-key="blog_plm_traceability_p1">Dans des secteurs réglementés, prouver la conformité d'un produit est aussi important que le produit lui-même. Avant l'arrivée d'un PLM, la traçabilité reposait sur des dossiers papier et la mémoire des ingénieurs. J'ai vu un audit repoussé parce qu'il était impossible de démontrer la généalogie complète d'un composant.</p>
+                    <p data-translate-key="blog_plm_traceability_p2">Avec un PLM, chaque décision, chaque validation et chaque version est enregistrée. Lors d'un projet piloté par Visiativ, nous avons pu répondre à un audit en quelques clics, fournissant l'historique complet des modifications d'une pièce critique. La confiance du client s'en est trouvée renforcée.</p>
                 </section>
 
                 <section class="blog-section article-section">
-                    <p>Ces cinq problématiques ne sont pas de simples cas d'école. Elles ont freiné des projets auxquels j'ai participé et m'ont parfois laissé un goût d'inachevé. Aujourd'hui, en tant que consultant PDM/PLM chez Visiativ, je mets cette expérience au service des entreprises qui veulent éviter ces pièges.</p>
+                    <p data-translate-key="blog_plm_outro_p1">Ces cinq problématiques ne sont pas de simples cas d'école. Elles ont freiné des projets auxquels j'ai participé et m'ont parfois laissé un goût d'inachevé. Aujourd'hui, en tant que consultant PDM/PLM chez Visiativ, je mets cette expérience au service des entreprises qui veulent éviter ces pièges.</p>
                 </section>
 
                 <section class="blog-section article-cta" data-component="cta">
                     <div class="cta-card">
-                        <h2>Envie de résoudre vos problématiques PLM&nbsp;?</h2>
-                        <p>Construisons ensemble une feuille de route pragmatique, ancrée dans votre réalité terrain. Une simple discussion peut révéler les priorités à adresser en premier.</p>
-                        <a class="hero-btn" href="/#contact">Planifier un échange</a>
+                        <h2 data-translate-key="blog_plm_cta_title">Envie de résoudre vos problématiques PLM&nbsp;?</h2>
+                        <p data-translate-key="blog_plm_cta_text">Construisons ensemble une feuille de route pragmatique, ancrée dans votre réalité terrain. Une simple discussion peut révéler les priorités à adresser en premier.</p>
+                        <a class="hero-btn" href="/#contact" data-translate-key="blog_plm_cta_button">Planifier un échange</a>
                     </div>
                 </section>
             </article>

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
                     <li><a href="#skills" class="nav-link" data-translate-key="nav_skills">Compétences</a></li>
                     <li><a href="#education" class="nav-link" data-translate-key="nav_education">Formation</a></li>
                     <li><a href="#contact" class="nav-link" data-translate-key="nav_contact">Contact</a></li>
-                    <li><a href="/blog/" class="nav-link">Blog</a></li>
+                    <li><a href="/blog/" class="nav-link" data-translate-key="nav_blog">Blog</a></li>
                 </ul>
                 <div class="language-switcher">
                     <button id="lang-fr" class="lang-btn active">FR</button>
@@ -270,7 +270,7 @@
                                 LinkedIn pour échanger professionnellement</span>
                         </div>
                     </div>
-                    <a href="/BAOUCH_CV_FR.pdf" class="btn btn-primary"
+                    <a href="/BAOUCH_CV_FR.pdf" class="btn btn-primary" data-cv-link
                         style="margin-top: 30px; position: relative; z-index: 50; cursor: pointer !important; display: inline-flex; align-items: center;">
                         <span data-translate-key="download_cv">Télécharger mon CV</span>
                         <svg width="20" height="20" viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary
- split the language switcher between portfolio-specific behaviour and blog pages, adding guards and shared date formatting
- add blog-specific translation data, template keys, and localized content for the blog index and individual articles
- extend blog JSON and front-end logic so hero highlights, cards, and dates render in the chosen language without overwriting article metadata

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d14598f688832fb077a567dc34f812