### PR TITLE
Guard hero grid initialization on pages without hero section

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -723,6 +723,9 @@ if (langEnButton) {
 
 function createHeroGrid() {
     const heroGrid = document.getElementById('heroGrid');
+    if (!heroGrid) {
+        return;
+    }
     const width = window.innerWidth;
     const height = window.innerHeight;
     const cellSize = 50;


### PR DESCRIPTION
## Summary
- guard the hero grid builder in script.js so blog pages without #heroGrid skip DOM writes safely

## Testing
- browser_container.run_playwright_script

------
https://chatgpt.com/codex/tasks/task_e_68d1c60b9808832fb6efcf0e7e9ac9cd