### PR TITLE
fix(chatbot): RAG non bloquant — Gemini répond toujours

### DIFF
--- a/api/ask-gemini.js
+++ b/api/ask-gemini.js
@@ -9,9 +9,21 @@ import {
     normalizeLang,
     fetchWithTimeout
 } from './_assistant.js';
-import { buildKnowledge } from './_rag.js';
 
 const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent';
+
+// RAG optionnel et NON bloquant : si la base de connaissances échoue à charger
+// ou à s'exécuter (bundling, erreur runtime…), le chatbot répond quand même
+// normalement via Gemini, sans le bloc de connaissances.
+async function safeKnowledge(question, language) {
+    try {
+        const { buildKnowledge } = await import('./_rag.js');
+        return buildKnowledge(question, { lang: language, k: 4 }) || '';
+    } catch (err) {
+        console.error('RAG indisponible (ignoré):', err && err.message);
+        return '';
+    }
+}
 
 export default async (req, res) => {
     if (req.method !== 'POST') {
@@ -38,7 +50,7 @@ export default async (req, res) => {
         parts: [{ text: turn.content }]
     }));
     // RAG : récupère les faits pertinents de la base curée pour ancrer la réponse.
-    const knowledge = buildKnowledge(question, { lang: language, k: 4 });
+    const knowledge = await safeKnowledge(question, language);
     contents.push({
         role: 'user',
         parts: [{ text: buildUserMessage({ question, context, pageType: normalizedPageType, knowledge }) }]


### PR DESCRIPTION
## Problème

Le chatbot pouvait ne plus répondre. Le backend est déjà 100% Gemini (`/api/ask-gemini`, aucun endpoint Claude), mais l'ajout du RAG créait un point de défaillance : si la base de connaissances échouait à se charger ou à s'exécuter en production, elle pouvait faire planter la fonction.

## Correctif

- Le RAG est désormais chargé en **import dynamique dans un `try/catch`** (`safeKnowledge`).
- Si le module RAG échoue (bundling, erreur runtime, quoi que ce soit), le chatbot **répond quand même normalement via Gemini**, simplement sans le bloc de connaissances.
- Aucune évolution future du RAG ne peut plus casser le chat.

## Validation

- Les 4 fichiers `api/*.js` passent le contrôle de syntaxe.
- Simulation du handler : le flux atteint bien l'appel Gemini, RAG chargé ou non.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017B2JajEtzysWgpoY1TrSXY

---
_Generated by [Claude Code](https://claude.ai/code/session_017B2JajEtzysWgpoY1TrSXY)_